### PR TITLE
Implement in-memory stream.

### DIFF
--- a/persistence/memory/doc.go
+++ b/persistence/memory/doc.go
@@ -1,0 +1,2 @@
+// Package memory is an in-memory persistence driver.
+package memory

--- a/persistence/memory/gingko_test.go
+++ b/persistence/memory/gingko_test.go
@@ -1,0 +1,15 @@
+package memory_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
+)
+
+func TestSuite(t *testing.T) {
+	type tag struct{}
+	gomega.RegisterFailHandler(ginkgo.Fail)
+	ginkgo.RunSpecs(t, reflect.TypeOf(tag{}).PkgPath())
+}

--- a/persistence/memory/stream.go
+++ b/persistence/memory/stream.go
@@ -1,0 +1,133 @@
+package memory
+
+import (
+	"context"
+	"errors"
+	"sync"
+
+	"github.com/dogmatiq/configkit/message"
+	"github.com/dogmatiq/infix/envelope"
+	"github.com/dogmatiq/infix/persistence"
+)
+
+// Stream is an implementation of persistence.Stream that stores messages
+// in-memory.
+type Stream struct {
+	m         sync.RWMutex
+	ready     chan struct{}
+	envelopes []*envelope.Envelope
+}
+
+// Open returns a cursor used to read messages from this stream.
+//
+// offset is the position of the first message to read. The first message on a
+// stream is always at offset 0.
+//
+// types is a set of message types indicating which message types are returned
+// by Cursor.Next().
+func (s *Stream) Open(
+	ctx context.Context,
+	offset uint64,
+	types message.TypeCollection,
+) (persistence.StreamCursor, error) {
+	return &cursor{
+		stream: s,
+		offset: offset,
+		closed: make(chan struct{}),
+		types:  types,
+	}, nil
+}
+
+// Append appends messages to the stream.
+func (s *Stream) Append(envelopes ...*envelope.Envelope) {
+	s.m.Lock()
+	defer s.m.Unlock()
+
+	s.envelopes = append(s.envelopes, envelopes...)
+
+	if s.ready != nil {
+		close(s.ready)
+		s.ready = nil
+	}
+}
+
+type cursor struct {
+	stream *Stream
+	offset uint64
+	types  message.TypeCollection
+	closed chan struct{}
+}
+
+var errCursorClosed = errors.New("cursor is closed")
+
+// Next returns the next relevant message in the stream.
+//
+// If the end of the stream is reached it blocks until a relevant message is
+// appended to the stream or ctx is canceled.
+func (c *cursor) Next(ctx context.Context) (*persistence.StreamMessage, error) {
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-c.closed:
+			return nil, errCursorClosed
+		default:
+		}
+
+		m, ready := c.get()
+
+		if ready == nil {
+			return m, nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-c.closed:
+			return nil, errCursorClosed
+		case <-ready:
+			continue // added to see coverage
+		}
+	}
+}
+
+// Close stops the cursor.
+//
+// Any current or future calls to Next() return a non-nil error.
+func (c *cursor) Close() error {
+	defer func() {
+		recover()
+	}()
+
+	close(c.closed)
+
+	return nil
+}
+
+// get returns the next relevant message, or if the end of the stream is
+// reached, it returns a "ready" channel that is closed when a message is
+// appended.
+func (c *cursor) get() (*persistence.StreamMessage, <-chan struct{}) {
+	c.stream.m.Lock()
+	defer c.stream.m.Unlock()
+
+	for uint64(len(c.stream.envelopes)) > c.offset {
+		offset := c.offset
+		c.offset++
+
+		env := c.stream.envelopes[offset]
+
+		if c.types.HasM(env.Message) {
+			return &persistence.StreamMessage{
+				Offset:   offset,
+				Envelope: env,
+			}, nil
+		}
+	}
+
+	if c.stream.ready == nil {
+		c.stream.ready = make(chan struct{})
+	}
+
+	return nil, c.stream.ready
+}

--- a/persistence/memory/stream_test.go
+++ b/persistence/memory/stream_test.go
@@ -1,0 +1,204 @@
+package memory_test
+
+import (
+	"context"
+	"time"
+
+	. "github.com/dogmatiq/configkit/fixtures"
+	"github.com/dogmatiq/configkit/message"
+	. "github.com/dogmatiq/dogma/fixtures"
+	"github.com/dogmatiq/infix/envelope"
+	"github.com/dogmatiq/infix/persistence"
+	. "github.com/dogmatiq/infix/persistence/memory"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"golang.org/x/sync/errgroup"
+)
+
+var _ = Describe("type Stream", func() {
+	var (
+		ctx    context.Context
+		cancel func()
+		stream *Stream
+		types  message.TypeSet
+	)
+
+	BeforeEach(func() {
+		ctx, cancel = context.WithTimeout(context.Background(), 3*time.Second)
+		stream = &Stream{}
+
+		types = message.NewTypeSet(MessageAType, MessageBType)
+
+		stream.Append(
+			&envelope.Envelope{Message: MessageA1},
+			&envelope.Envelope{Message: MessageB1},
+			&envelope.Envelope{Message: MessageA2},
+			&envelope.Envelope{Message: MessageB2},
+		)
+	})
+
+	AfterEach(func() {
+		cancel()
+	})
+
+	Describe("func Open()", func() {
+		It("honours the initial offset", func() {
+			cur, err := stream.Open(ctx, 2, types)
+			Expect(err).ShouldNot(HaveOccurred())
+			defer cur.Close()
+
+			m, err := cur.Next(ctx)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(m).To(Equal(
+				&persistence.StreamMessage{
+					Offset:   2,
+					Envelope: &envelope.Envelope{Message: MessageA2},
+				},
+			))
+
+			m, err = cur.Next(ctx)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(m).To(Equal(
+				&persistence.StreamMessage{
+					Offset:   3,
+					Envelope: &envelope.Envelope{Message: MessageB2},
+				},
+			))
+		})
+
+		It("limits results to the supplied message types", func() {
+			cur, err := stream.Open(ctx, 0, message.NewTypeSet(MessageAType))
+			Expect(err).ShouldNot(HaveOccurred())
+			defer cur.Close()
+
+			m, err := cur.Next(ctx)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(m).To(Equal(
+				&persistence.StreamMessage{
+					Offset:   0,
+					Envelope: &envelope.Envelope{Message: MessageA1},
+				},
+			))
+
+			m, err = cur.Next(ctx)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(m).To(Equal(
+				&persistence.StreamMessage{
+					Offset:   2,
+					Envelope: &envelope.Envelope{Message: MessageA2},
+				},
+			))
+		})
+	})
+
+	Describe("func Append()", func() {
+		It("wakes all blocked cursors", func() {
+			cursors := 3 // number of cursors to open
+
+			// barrier is used to delay the main (appending) goroutine until the
+			// cursors have started blocking.
+			barrier := make(chan struct{}, cursors)
+
+			g, ctx := errgroup.WithContext(ctx)
+
+			// start the cursors
+			for i := 0; i < cursors; i++ {
+				g.Go(func() error {
+					defer GinkgoRecover()
+
+					cur, err := stream.Open(ctx, 4, types)
+					if err != nil {
+						return err
+					}
+					defer cur.Close()
+
+					barrier <- struct{}{}
+					m, err := cur.Next(ctx)
+					if err != nil {
+						return err
+					}
+
+					Expect(m).To(Equal(
+						&persistence.StreamMessage{
+							Offset:   4,
+							Envelope: &envelope.Envelope{Message: MessageA3},
+						},
+					))
+
+					return nil
+				})
+			}
+
+			// wait for the cursors to signal they are about to block
+			for i := 0; i < cursors; i++ {
+				select {
+				case <-barrier:
+				case <-ctx.Done():
+					Expect(ctx.Err()).ShouldNot(HaveOccurred())
+				}
+			}
+
+			// add a little delay to ensure the cursors actually start blocking
+			time.Sleep(100 * time.Millisecond)
+
+			// wake the consumers
+			stream.Append(
+				&envelope.Envelope{Message: MessageA3},
+			)
+
+			err := g.Wait()
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+	})
+
+	Describe("type cursor", func() {
+		Describe("func Next()", func() {
+			It("returns an error if the cursor is already closed", func() {
+				cur, err := stream.Open(ctx, 4, types)
+				Expect(err).ShouldNot(HaveOccurred())
+
+				cur.Close()
+
+				_, err = cur.Next(ctx)
+				Expect(err).Should(HaveOccurred())
+			})
+
+			It("returns an error if the context is already canceled", func() {
+				cur, err := stream.Open(ctx, 4, types)
+				Expect(err).ShouldNot(HaveOccurred())
+				defer cur.Close()
+
+				cancel()
+				_, err = cur.Next(ctx)
+				Expect(err).Should(HaveOccurred())
+			})
+
+			It("returns an error if the cursor is closed while blocked", func() {
+				cur, err := stream.Open(ctx, 4, types)
+				Expect(err).ShouldNot(HaveOccurred())
+
+				go func() {
+					time.Sleep(100 * time.Millisecond)
+					cur.Close()
+				}()
+
+				_, err = cur.Next(ctx)
+				Expect(err).Should(HaveOccurred())
+			})
+
+			It("returns an error if the context is canceled while blocked", func() {
+				cur, err := stream.Open(ctx, 4, types)
+				Expect(err).ShouldNot(HaveOccurred())
+				defer cur.Close()
+
+				go func() {
+					time.Sleep(100 * time.Millisecond)
+					cancel()
+				}()
+
+				_, err = cur.Next(ctx)
+				Expect(err).Should(HaveOccurred())
+			})
+		})
+	})
+})


### PR DESCRIPTION
This PR adds an in-memory implementation of the `persistence.Stream`.

I'm going to try to keep an in-memory persistence layer in Infix, since it is designed for embedding in single-binary apps. This would replace any use-case we might have for using the testkit engine for anything outside of actual tests. (And it will be properly concurrent, unlike testkit).