### PR TITLE
Implement `envelope.BoundPacker`.

### DIFF
--- a/envelope/boundpacker.go
+++ b/envelope/boundpacker.go
@@ -1,0 +1,94 @@
+package envelope
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/dogmatiq/configkit"
+	"github.com/dogmatiq/dogma"
+)
+
+// BoundPacker is an envelope packer that's bound to a specific source handler.
+type BoundPacker struct {
+	Packer        *Packer
+	Cause         *Envelope
+	HandlerConfig configkit.RichHandler
+	InstanceID    string
+}
+
+// PackChildCommand returns a new command envelope containing the given message
+// and configured as a child of cause.
+func (p *BoundPacker) PackChildCommand(m dogma.Message) *Envelope {
+	p.HandlerConfig.HandlerType().MustBe(
+		configkit.ProcessHandlerType,
+	)
+
+	env := p.Packer.PackChildCommand(
+		p.Cause,
+		m,
+		p.HandlerConfig.Identity(),
+		p.InstanceID,
+	)
+
+	if p.HandlerConfig.MessageTypes().Produced.HasM(m) {
+		return env
+	}
+
+	panic(fmt.Sprintf(
+		"the '%s' handler is not configured to produced commands of type %T",
+		p.HandlerConfig.Identity().Name,
+		m,
+	))
+}
+
+// PackChildEvent returns a new event envelope containing the given message and
+// configured as a child of cause.
+func (p *BoundPacker) PackChildEvent(m dogma.Message) *Envelope {
+	p.HandlerConfig.HandlerType().MustBe(
+		configkit.AggregateHandlerType,
+		configkit.IntegrationHandlerType,
+	)
+
+	env := p.Packer.PackChildEvent(
+		p.Cause,
+		m,
+		p.HandlerConfig.Identity(),
+		p.InstanceID,
+	)
+
+	if p.HandlerConfig.MessageTypes().Produced.HasM(m) {
+		return env
+	}
+
+	panic(fmt.Sprintf(
+		"the '%s' handler is not configured to produced events of type %T",
+		p.HandlerConfig.Identity().Name,
+		m,
+	))
+}
+
+// PackChildTimeout returns a new timeout envelope containing the given message
+// and configured as a child of cause.
+func (p *BoundPacker) PackChildTimeout(m dogma.Message, t time.Time) *Envelope {
+	p.HandlerConfig.HandlerType().MustBe(
+		configkit.ProcessHandlerType,
+	)
+
+	env := p.Packer.PackChildTimeout(
+		p.Cause,
+		m,
+		t,
+		p.HandlerConfig.Identity(),
+		p.InstanceID,
+	)
+
+	if p.HandlerConfig.MessageTypes().Produced.HasM(m) {
+		return env
+	}
+
+	panic(fmt.Sprintf(
+		"the '%s' handler is not configured to produced events of type %T",
+		p.HandlerConfig.Identity().Name,
+		m,
+	))
+}

--- a/envelope/boundpacker_test.go
+++ b/envelope/boundpacker_test.go
@@ -1,0 +1,243 @@
+package envelope_test
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/dogmatiq/configkit"
+	. "github.com/dogmatiq/configkit/fixtures"
+	"github.com/dogmatiq/configkit/message"
+	"github.com/dogmatiq/dogma"
+	. "github.com/dogmatiq/dogma/fixtures"
+	. "github.com/dogmatiq/infix/envelope"
+	. "github.com/dogmatiq/marshalkit/fixtures"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("type BoundPacker", func() {
+	var (
+		seq    int
+		now    time.Time
+		packer *Packer
+	)
+
+	BeforeEach(func() {
+		seq = 0
+		now = time.Now()
+		packer = &Packer{
+			Application: configkit.MustNewIdentity("<app-name>", "<app-key>"),
+			Marshaler:   Marshaler,
+			Roles: message.TypeRoles{
+				MessageCType: message.CommandRole,
+				MessageDType: message.CommandRole,
+				MessageEType: message.EventRole,
+				MessageFType: message.EventRole,
+				MessageTType: message.TimeoutRole,
+				MessageUType: message.TimeoutRole,
+			},
+			GenerateID: func() string {
+				seq++
+				return fmt.Sprintf("%08d", seq)
+			},
+			Now: func() time.Time {
+				return now
+			},
+		}
+	})
+
+	Describe("func PackChildCommand()", func() {
+		var (
+			parent *Envelope
+			bound  *BoundPacker
+		)
+
+		BeforeEach(func() {
+			parent = &Envelope{
+				MetaData: MetaData{
+					MessageID:     "<parent>",
+					CausationID:   "<parent>",
+					CorrelationID: "<parent>",
+					Source: Source{
+						Application: configkit.MustNewIdentity("<app-name>", "<app-key>"),
+					},
+				},
+				Message: MessageE1,
+				Packet:  MessageE1Packet,
+			}
+
+			cfg := configkit.FromProcess(&ProcessMessageHandler{
+				ConfigureFunc: func(c dogma.ProcessConfigurer) {
+					c.Identity("<process-name>", "<process-key>")
+					c.ConsumesEventType(MessageE{})
+					c.ProducesCommandType(MessageC{})
+				},
+			})
+
+			bound = packer.Bind(
+				parent,
+				cfg,
+				"<instance>",
+			)
+		})
+
+		It("returns a new envelope", func() {
+			env := bound.PackChildCommand(MessageC1)
+
+			Expect(env).To(Equal(
+				&Envelope{
+					MetaData: MetaData{
+						MessageID:     "00000001",
+						CausationID:   "<parent>",
+						CorrelationID: "<parent>",
+						Source: Source{
+							Application: configkit.MustNewIdentity("<app-name>", "<app-key>"),
+							Handler:     configkit.MustNewIdentity("<process-name>", "<process-key>"),
+							InstanceID:  "<instance>",
+						},
+						CreatedAt: now,
+					},
+					Message: MessageC1,
+					Packet:  MessageC1Packet,
+				},
+			))
+		})
+
+		It("panics if the message type is not produced by this handler", func() {
+			Expect(func() {
+				bound.PackChildCommand(MessageD1)
+			}).To(Panic())
+		})
+	})
+
+	Describe("func PackChildEvent()", func() {
+		var (
+			parent *Envelope
+			bound  *BoundPacker
+		)
+
+		BeforeEach(func() {
+			parent = &Envelope{
+				MetaData: MetaData{
+					MessageID:     "<parent>",
+					CausationID:   "<parent>",
+					CorrelationID: "<parent>",
+					Source: Source{
+						Application: configkit.MustNewIdentity("<app-name>", "<app-key>"),
+					},
+				},
+				Message: MessageC1,
+				Packet:  MessageC1Packet,
+			}
+
+			cfg := configkit.FromAggregate(&AggregateMessageHandler{
+				ConfigureFunc: func(c dogma.AggregateConfigurer) {
+					c.Identity("<aggregate-name>", "<aggregate-key>")
+					c.ConsumesCommandType(MessageC{})
+					c.ProducesEventType(MessageE{})
+				},
+			})
+
+			bound = packer.Bind(
+				parent,
+				cfg,
+				"<instance>",
+			)
+		})
+
+		It("returns a new envelope", func() {
+			env := bound.PackChildEvent(MessageE1)
+
+			Expect(env).To(Equal(
+				&Envelope{
+					MetaData: MetaData{
+						MessageID:     "00000001",
+						CausationID:   "<parent>",
+						CorrelationID: "<parent>",
+						Source: Source{
+							Application: configkit.MustNewIdentity("<app-name>", "<app-key>"),
+							Handler:     configkit.MustNewIdentity("<aggregate-name>", "<aggregate-key>"),
+							InstanceID:  "<instance>",
+						},
+						CreatedAt: now,
+					},
+					Message: MessageE1,
+					Packet:  MessageE1Packet,
+				},
+			))
+		})
+
+		It("panics if the message type is not produced by this handler", func() {
+			Expect(func() {
+				bound.PackChildEvent(MessageF1)
+			}).To(Panic())
+		})
+	})
+
+	Describe("func PackChildTimeout()", func() {
+		var (
+			parent *Envelope
+			bound  *BoundPacker
+		)
+
+		BeforeEach(func() {
+			parent = &Envelope{
+				MetaData: MetaData{
+					MessageID:     "<parent>",
+					CausationID:   "<parent>",
+					CorrelationID: "<parent>",
+					Source: Source{
+						Application: configkit.MustNewIdentity("<app-name>", "<app-key>"),
+					},
+				},
+				Message: MessageE1,
+				Packet:  MessageE1Packet,
+			}
+
+			cfg := configkit.FromProcess(&ProcessMessageHandler{
+				ConfigureFunc: func(c dogma.ProcessConfigurer) {
+					c.Identity("<process-name>", "<process-key>")
+					c.ConsumesEventType(MessageE{})
+					c.ProducesCommandType(MessageC{})
+					c.SchedulesTimeoutType(MessageT{})
+				},
+			})
+
+			bound = packer.Bind(
+				parent,
+				cfg,
+				"<instance>",
+			)
+		})
+
+		It("returns a new envelope", func() {
+			scheduledFor := time.Now()
+			env := bound.PackChildTimeout(MessageT1, scheduledFor)
+
+			Expect(env).To(Equal(
+				&Envelope{
+					MetaData: MetaData{
+						MessageID:     "00000001",
+						CausationID:   "<parent>",
+						CorrelationID: "<parent>",
+						Source: Source{
+							Application: configkit.MustNewIdentity("<app-name>", "<app-key>"),
+							Handler:     configkit.MustNewIdentity("<process-name>", "<process-key>"),
+							InstanceID:  "<instance>",
+						},
+						CreatedAt:    now,
+						ScheduledFor: scheduledFor,
+					},
+					Message: MessageT1,
+					Packet:  MessageT1Packet,
+				},
+			))
+		})
+
+		It("panics if the message type is not produced by this handler", func() {
+			Expect(func() {
+				bound.PackChildTimeout(MessageU1, time.Now())
+			}).To(Panic())
+		})
+	})
+})

--- a/envelope/packer.go
+++ b/envelope/packer.go
@@ -74,16 +74,16 @@ func (p *Packer) PackEvent(m dogma.Message) *Envelope {
 	)
 }
 
-// PackChildCommand returns a new command envelope containing the given
-// message and configured as a child of cause.
+// PackChildCommand returns a new command envelope containing the given message
+// and configured as a child of cause.
 func (p *Packer) PackChildCommand(
 	cause *Envelope,
 	m dogma.Message,
 	handler configkit.Identity,
 	instanceID string,
 ) *Envelope {
-	t := message.TypeOf(cause.Message)
-	p.Roles[t].MustBe(message.EventRole, message.TimeoutRole)
+	mt := message.TypeOf(cause.Message)
+	p.Roles[mt].MustBe(message.EventRole, message.TimeoutRole)
 
 	id := p.generateID()
 
@@ -98,16 +98,16 @@ func (p *Packer) PackChildCommand(
 	)
 }
 
-// PackChildEvent returns a new event envelope containing the given message
-// and configured as a child of cause.
+// PackChildEvent returns a new event envelope containing the given message and
+// configured as a child of cause.
 func (p *Packer) PackChildEvent(
 	cause *Envelope,
 	m dogma.Message,
 	handler configkit.Identity,
 	instanceID string,
 ) *Envelope {
-	t := message.TypeOf(cause.Message)
-	p.Roles[t].MustBe(message.CommandRole)
+	mt := message.TypeOf(cause.Message)
+	p.Roles[mt].MustBe(message.CommandRole)
 
 	id := p.generateID()
 
@@ -122,17 +122,17 @@ func (p *Packer) PackChildEvent(
 	)
 }
 
-// PackChildTimeout returns a new timeout envelope containing the given
-// message and configured as a child of cause.
+// PackChildTimeout returns a new timeout envelope containing the given message
+// and configured as a child of cause.
 func (p *Packer) PackChildTimeout(
 	cause *Envelope,
 	m dogma.Message,
-	sf time.Time,
+	t time.Time,
 	handler configkit.Identity,
 	instanceID string,
 ) *Envelope {
-	t := message.TypeOf(cause.Message)
-	p.Roles[t].MustBe(message.EventRole, message.TimeoutRole)
+	mt := message.TypeOf(cause.Message)
+	p.Roles[mt].MustBe(message.EventRole, message.TimeoutRole)
 
 	id := p.generateID()
 
@@ -162,8 +162,8 @@ func (p *Packer) new(
 	handler configkit.Identity,
 	instanceID string,
 ) *Envelope {
-	t := message.TypeOf(m)
-	p.Roles[t].MustBe(r)
+	mt := message.TypeOf(m)
+	p.Roles[mt].MustBe(r)
 
 	return &Envelope{
 		MetaData{

--- a/envelope/packer.go
+++ b/envelope/packer.go
@@ -146,9 +146,29 @@ func (p *Packer) PackChildTimeout(
 		instanceID,
 	)
 
-	env.ScheduledFor = sf
+	env.ScheduledFor = t
 
 	return env
+}
+
+// Bind returns a packer bound to the given handler.
+func (p *Packer) Bind(
+	cause *Envelope,
+	cfg configkit.RichHandler,
+	instanceID string,
+) *BoundPacker {
+	if instanceID == "" {
+		cfg.HandlerType().MustBe(configkit.IntegrationHandlerType)
+	} else {
+		cfg.HandlerType().MustBe(configkit.AggregateHandlerType, configkit.ProcessHandlerType)
+	}
+
+	return &BoundPacker{
+		Packer:        p,
+		Cause:         cause,
+		HandlerConfig: cfg,
+		InstanceID:    instanceID,
+	}
 }
 
 // new returns a new envelope, it panics if the given message type does not map


### PR DESCRIPTION
A bound packer is a `Packer` that is bound to specific parent message and handler. It validates that any new envelopes contain messages intended to be produced by that handler.