### PR TITLE
Convert PosgreSQL "query_canceled" errors into context errors.

### DIFF
--- a/persistence/provider/sql/driver.go
+++ b/persistence/provider/sql/driver.go
@@ -14,6 +14,9 @@ import (
 type Driver interface {
 	eventStoreDriver
 
+	// Begin starts a transaction for use in a peristence.Transaction.
+	Begin(ctx context.Context, db *sql.DB) (*sql.Tx, error)
+
 	// LockApplication acquires an exclusive lock on an application's data.
 	//
 	// r is a function that releases the lock, if acquired successfully.

--- a/persistence/provider/sql/mysql/driver.go
+++ b/persistence/provider/sql/mysql/driver.go
@@ -15,6 +15,11 @@ var Driver driver
 
 type driver struct{}
 
+// Begin starts a transaction.
+func (driver) Begin(ctx context.Context, db *sql.DB) (*sql.Tx, error) {
+	return db.BeginTx(ctx, nil)
+}
+
 // LockApplication acquires an exclusive lock on an application's data.
 //
 // r is a function that releases the lock, if acquired successfully.

--- a/persistence/provider/sql/postgres/driver.go
+++ b/persistence/provider/sql/postgres/driver.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Driver is an implementation of sql.Driver for PostgreSQL.
-var Driver driver
+var Driver errorConverter
 
 type driver struct{}
 

--- a/persistence/provider/sql/postgres/driver.go
+++ b/persistence/provider/sql/postgres/driver.go
@@ -13,6 +13,11 @@ var Driver errorConverter
 
 type driver struct{}
 
+// Begin starts a transaction.
+func (driver) Begin(ctx context.Context, db *sql.DB) (*sql.Tx, error) {
+	return db.BeginTx(ctx, nil)
+}
+
 // LockApplication acquires an exclusive lock on an application's data.
 //
 // r is a function that releases the lock, if acquired successfully.

--- a/persistence/provider/sql/postgres/error.go
+++ b/persistence/provider/sql/postgres/error.go
@@ -38,6 +38,11 @@ type errorConverter struct {
 	d driver
 }
 
+func (d errorConverter) Begin(ctx context.Context, db *sql.DB) (*sql.Tx, error) {
+	tx, err := db.BeginTx(ctx, nil)
+	return tx, convertContextErrors(ctx, err)
+}
+
 func (d errorConverter) LockApplication(
 	ctx context.Context,
 	db *sql.DB,

--- a/persistence/provider/sql/postgres/error.go
+++ b/persistence/provider/sql/postgres/error.go
@@ -1,0 +1,118 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+
+	"github.com/dogmatiq/infix/draftspecs/envelopespec"
+	"github.com/dogmatiq/infix/persistence/eventstore"
+	"github.com/lib/pq"
+)
+
+// convertContextErrors converts PostgreSQL "query_canceled" errors into a
+// context.Canceled or DeadlineExceeeded error.
+//
+// See https://github.com/dogmatiq/infix/issues/35.
+func convertContextErrors(ctx context.Context, err error) error {
+	var e pq.Error
+
+	if errors.As(err, &e) {
+		if e.Code.Name() == "query_canceled" {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+		}
+	}
+
+	return err
+}
+
+// errorConverter is an implementation of persistence.Driver that decorates the
+// PostgreSQL driver in order to convert native "query_canceled" errors into
+// regular context.Canceled / DeadlineExceeded errors.
+//
+// The error conversion is implemented this way so that conversions don't get
+// missed when new methods are added to the persistence.Driver interface.
+type errorConverter struct {
+	d driver
+}
+
+func (d errorConverter) LockApplication(
+	ctx context.Context,
+	db *sql.DB,
+	ak string,
+) (func() error, error) {
+	r, err := d.d.LockApplication(ctx, db, ak)
+	return r, convertContextErrors(ctx, err)
+}
+
+//
+// eventstore.Repository
+//
+
+func (d errorConverter) UpdateNextOffset(
+	ctx context.Context,
+	tx *sql.Tx,
+	ak string,
+	n eventstore.Offset,
+) (eventstore.Offset, error) {
+	o, err := d.d.UpdateNextOffset(ctx, tx, ak, n)
+	return o, convertContextErrors(ctx, err)
+}
+
+func (d errorConverter) InsertEvents(
+	ctx context.Context,
+	tx *sql.Tx,
+	o eventstore.Offset,
+	envelopes []*envelopespec.Envelope,
+) error {
+	err := d.d.InsertEvents(ctx, tx, o, envelopes)
+	return convertContextErrors(ctx, err)
+}
+
+func (d errorConverter) InsertEventFilter(
+	ctx context.Context,
+	db *sql.DB,
+	ak string,
+	f eventstore.Filter,
+) (int64, error) {
+	id, err := d.d.InsertEventFilter(ctx, db, ak, f)
+	return id, convertContextErrors(ctx, err)
+}
+
+func (d errorConverter) DeleteEventFilter(
+	ctx context.Context,
+	db *sql.DB,
+	f int64,
+) error {
+	err := d.d.DeleteEventFilter(ctx, db, f)
+	return convertContextErrors(ctx, err)
+}
+
+func (d errorConverter) PurgeEventFilters(
+	ctx context.Context,
+	db *sql.DB,
+	ak string,
+) error {
+	err := d.d.PurgeEventFilters(ctx, db, ak)
+	return convertContextErrors(ctx, err)
+}
+
+func (d errorConverter) SelectEvents(
+	ctx context.Context,
+	db *sql.DB,
+	ak string,
+	q eventstore.Query,
+	f int64,
+) (*sql.Rows, error) {
+	rows, err := d.d.SelectEvents(ctx, db, ak, q, f)
+	return rows, convertContextErrors(ctx, err)
+}
+
+func (d errorConverter) ScanEvent(
+	rows *sql.Rows,
+	ev *eventstore.Event,
+) error {
+	return d.d.ScanEvent(rows, ev)
+}

--- a/persistence/provider/sql/sqlite/driver.go
+++ b/persistence/provider/sql/sqlite/driver.go
@@ -26,6 +26,11 @@ const (
 	lockExpiryOffset = 3 * time.Second
 )
 
+// Begin starts a transaction.
+func (driver) Begin(ctx context.Context, db *sql.DB) (*sql.Tx, error) {
+	return db.BeginTx(ctx, nil)
+}
+
 // LockApplication acquires an exclusive lock on an application's data.
 //
 // r is a function that releases the lock, if acquired successfully.

--- a/persistence/provider/sql/transaction.go
+++ b/persistence/provider/sql/transaction.go
@@ -56,7 +56,7 @@ func (t *transaction) begin(ctx context.Context) error {
 	var err error
 
 	if t.actual == nil {
-		t.actual, err = t.ds.db.BeginTx(ctx, nil)
+		t.actual, err = t.ds.driver.Begin(ctx, t.ds.db)
 	}
 
 	return err


### PR DESCRIPTION
Fixes #35.