### PR TITLE
Accept "next attempt" time directly when enqueuing messages.

### DIFF
--- a/persistence/provider/sql/postgres/error.go
+++ b/persistence/provider/sql/postgres/error.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"time"
 
 	"github.com/dogmatiq/infix/draftspecs/envelopespec"
 	"github.com/dogmatiq/infix/persistence/subsystem/eventstore"
@@ -141,13 +142,14 @@ func (d errorConverter) ScanEvent(
 // queue
 //
 
-func (d errorConverter) InsertQueueMessages(
+func (d errorConverter) InsertQueueMessage(
 	ctx context.Context,
 	tx *sql.Tx,
 	ak string,
-	envelopes []*envelopespec.Envelope,
+	env *envelopespec.Envelope,
+	n time.Time,
 ) error {
-	err := d.d.InsertQueueMessages(ctx, tx, ak, envelopes)
+	err := d.d.InsertQueueMessage(ctx, tx, ak, env, n)
 	return convertContextErrors(ctx, err)
 }
 

--- a/persistence/provider/sql/postgres/queue.go
+++ b/persistence/provider/sql/postgres/queue.go
@@ -10,30 +10,20 @@ import (
 	"github.com/dogmatiq/infix/persistence/subsystem/queue"
 )
 
-// InsertQueueMessages saves messages to the queue.
-func (driver) InsertQueueMessages(
+// InsertQueueMessage saves a messages to the queue.
+func (driver) InsertQueueMessage(
 	ctx context.Context,
 	tx *sql.Tx,
 	ak string,
-	envelopes []*envelopespec.Envelope,
+	env *envelopespec.Envelope,
+	n time.Time,
 ) (err error) {
 	defer sqlx.Recover(&err)
 
-	for _, env := range envelopes {
-		data := env.MetaData.ScheduledFor
-		if data == "" {
-			data = env.MetaData.CreatedAt
-		}
-
-		next, err := time.Parse(time.RFC3339Nano, data)
-		if err != nil {
-			return err
-		}
-
-		sqlx.Exec(
-			ctx,
-			tx,
-			`INSERT INTO infix.queue (
+	sqlx.Exec(
+		ctx,
+		tx,
+		`INSERT INTO infix.queue (
 				app_key,
 				next_attempt_at,
 				message_id,
@@ -52,23 +42,22 @@ func (driver) InsertQueueMessages(
 			) VALUES (
 				$1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15
 			) ON CONFLICT (app_key, message_id) DO NOTHING`,
-			ak,
-			next,
-			env.MetaData.MessageId,
-			env.MetaData.CausationId,
-			env.MetaData.CorrelationId,
-			env.MetaData.Source.Application.Name,
-			env.MetaData.Source.Application.Key,
-			env.MetaData.Source.Handler.Name,
-			env.MetaData.Source.Handler.Key,
-			env.MetaData.Source.InstanceId,
-			env.MetaData.CreatedAt,
-			env.MetaData.ScheduledFor,
-			env.PortableName,
-			env.MediaType,
-			env.Data,
-		)
-	}
+		ak,
+		n,
+		env.MetaData.MessageId,
+		env.MetaData.CausationId,
+		env.MetaData.CorrelationId,
+		env.MetaData.Source.Application.Name,
+		env.MetaData.Source.Application.Key,
+		env.MetaData.Source.Handler.Name,
+		env.MetaData.Source.Handler.Key,
+		env.MetaData.Source.InstanceId,
+		env.MetaData.CreatedAt,
+		env.MetaData.ScheduledFor,
+		env.PortableName,
+		env.MediaType,
+		env.Data,
+	)
 
 	return nil
 }

--- a/persistence/subsystem/queue/transaction.go
+++ b/persistence/subsystem/queue/transaction.go
@@ -2,6 +2,7 @@ package queue
 
 import (
 	"context"
+	"time"
 
 	"github.com/dogmatiq/infix/draftspecs/envelopespec"
 )
@@ -9,10 +10,13 @@ import (
 // Transaction defines the primitive persistence operations for manipulating the
 // message queue.
 type Transaction interface {
-	// AddMessagesToQueue adds messages to the application's message queue.
-	AddMessagesToQueue(
+	// AddMessageToQueue add a message to the application's message queue.
+	//
+	// n indicates when the next attempt at handling the message is to be made.
+	AddMessageToQueue(
 		ctx context.Context,
-		envelopes []*envelopespec.Envelope,
+		env *envelopespec.Envelope,
+		n time.Time,
 	) error
 
 	// RemoveMessageFromQueue removes a specific message from the application's


### PR DESCRIPTION
This PR changes the `AddMessagesToQueue()` methods into the singular `AddMessageToQueue()` and requires the user to supply the time of the next (first) time that the message should be attempted.

This allows us to avoid unmarshaling previously marshaled data to determine the correct time to use.