### PR TITLE
Replace `SaveEvents()` with the singular `SaveEvent()`.

### DIFF
--- a/envelope/marshaling.go
+++ b/envelope/marshaling.go
@@ -33,25 +33,6 @@ func Marshal(
 	}, nil
 }
 
-// MarshalMany marshals multiple message envelopes to their protobuf
-// representations.
-func MarshalMany(
-	m marshalkit.ValueMarshaler,
-	envelopes []*Envelope,
-) ([]*envelopespec.Envelope, error) {
-	out := make([]*envelopespec.Envelope, len(envelopes))
-
-	var err error
-	for i, env := range envelopes {
-		out[i], err = Marshal(m, env)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	return out, nil
-}
-
 // MustMarshal marshals a message envelope to its protobuf representation, or
 // panics if it is unable to do so.
 func MustMarshal(
@@ -59,20 +40,6 @@ func MustMarshal(
 	in *Envelope,
 ) *envelopespec.Envelope {
 	out, err := Marshal(m, in)
-	if err != nil {
-		panic(err)
-	}
-
-	return out
-}
-
-// MustMarshalMany marshals multiple messages envelope to their protobuf
-// representations, or panics if it is unable to do so.
-func MustMarshalMany(
-	m marshalkit.ValueMarshaler,
-	envelopes []*Envelope,
-) []*envelopespec.Envelope {
-	out, err := MarshalMany(m, envelopes)
 	if err != nil {
 		panic(err)
 	}

--- a/envelope/marshaling_test.go
+++ b/envelope/marshaling_test.go
@@ -69,40 +69,6 @@ var _ = Describe("func Marshal()", func() {
 
 })
 
-var _ = Describe("func MarshalMany()", func() {
-	It("marshals multiple envelopes", func() {
-		in1 := NewEnvelope("<id-2>", MessageA1)
-		in2 := NewEnvelope("<id-2>", MessageA2)
-
-		out, err := MarshalMany(
-			Marshaler,
-			[]*Envelope{
-				in1,
-				in2,
-			},
-		)
-		Expect(err).ShouldNot(HaveOccurred())
-
-		Expect(out).To(Equal(
-			[]*envelopespec.Envelope{
-				MustMarshal(Marshaler, in1),
-				MustMarshal(Marshaler, in2),
-			},
-		))
-	})
-
-	It("returns an error if marshaling fails", func() {
-		in := NewEnvelope("<id>", MessageA1)
-		in.Message = "<unsupported type>"
-
-		_, err := MarshalMany(
-			Marshaler,
-			[]*Envelope{in},
-		)
-		Expect(err).Should(HaveOccurred())
-	})
-})
-
 var _ = Describe("func MustMarshal()", func() {
 	It("marshals the envelope", func() {
 		in := NewEnvelope("<id>", MessageA1)
@@ -120,39 +86,6 @@ var _ = Describe("func MustMarshal()", func() {
 
 		Expect(func() {
 			MustMarshal(Marshaler, in)
-		}).To(Panic())
-	})
-})
-
-var _ = Describe("func MustMarshalMany()", func() {
-	It("marshals multiple envelopes", func() {
-		in1 := NewEnvelope("<id-2>", MessageA1)
-		in2 := NewEnvelope("<id-2>", MessageA2)
-		out := MustMarshalMany(
-			Marshaler,
-			[]*Envelope{
-				in1,
-				in2,
-			},
-		)
-
-		Expect(out).To(Equal(
-			[]*envelopespec.Envelope{
-				MustMarshal(Marshaler, in1),
-				MustMarshal(Marshaler, in2),
-			},
-		))
-	})
-
-	It("panics if marshaling fails", func() {
-		in := NewEnvelope("<id>", MessageA1)
-		in.Message = "<unsupported type>"
-
-		Expect(func() {
-			MustMarshalMany(
-				Marshaler,
-				[]*Envelope{in},
-			)
 		}).To(Panic())
 	})
 })

--- a/eventstream/eventstore_test.go
+++ b/eventstream/eventstore_test.go
@@ -37,11 +37,13 @@ var _ = Describe("type EventStoreStream", func() {
 					Expect(err).ShouldNot(HaveOccurred())
 					defer tx.Rollback()
 
-					_, err = tx.SaveEvents(
-						ctx,
-						envelope.MustMarshalMany(stream.Marshaler, envelopes),
-					)
-					Expect(err).ShouldNot(HaveOccurred())
+					for _, env := range envelopes {
+						_, err = tx.SaveEvent(
+							ctx,
+							envelope.MustMarshal(stream.Marshaler, env),
+						)
+						Expect(err).ShouldNot(HaveOccurred())
+					}
 
 					err = tx.Commit(ctx)
 					Expect(err).ShouldNot(HaveOccurred())

--- a/persistence/internal/providertest/datastore.go
+++ b/persistence/internal/providertest/datastore.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	dogmafixtures "github.com/dogmatiq/dogma/fixtures"
-	"github.com/dogmatiq/infix/draftspecs/envelopespec"
 	infixfixtures "github.com/dogmatiq/infix/fixtures"
 	"github.com/dogmatiq/infix/persistence"
 	"github.com/onsi/ginkgo"
@@ -110,10 +109,7 @@ func declareDataStoreTests(
 
 							env := infixfixtures.NewEnvelopeProto("<id>", dogmafixtures.MessageA1)
 
-							if _, err := tx.SaveEvents(
-								*ctx,
-								[]*envelopespec.Envelope{env},
-							); err != nil {
+							if _, err := tx.SaveEvent(*ctx, env); err != nil {
 								result <- err
 								return
 							}

--- a/persistence/internal/providertest/transaction.go
+++ b/persistence/internal/providertest/transaction.go
@@ -53,9 +53,9 @@ func declareTransactionTests(
 				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 			})
 
-			ginkgo.Describe("func SaveEvents()", func() {
+			ginkgo.Describe("func SaveEvent()", func() {
 				ginkgo.It("returns an error", func() {
-					_, err := transaction.SaveEvents(*ctx, nil)
+					_, err := transaction.SaveEvent(*ctx, nil)
 					gomega.Expect(err).To(gomega.Equal(persistence.ErrTransactionClosed))
 				})
 			})
@@ -88,9 +88,9 @@ func declareTransactionTests(
 				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 			})
 
-			ginkgo.Describe("func SaveEvents()", func() {
+			ginkgo.Describe("func SaveEvent()", func() {
 				ginkgo.It("returns an error", func() {
-					_, err := transaction.SaveEvents(*ctx, nil)
+					_, err := transaction.SaveEvent(*ctx, nil)
 					gomega.Expect(err).To(gomega.Equal(persistence.ErrTransactionClosed))
 				})
 			})

--- a/persistence/provider/boltdb/database_test.go
+++ b/persistence/provider/boltdb/database_test.go
@@ -34,7 +34,7 @@ var _ = Describe("type database", func() {
 			defer tx.Rollback()
 
 			// Perform a write to cause the actual transaction to be started.
-			_, err = tx.SaveEvents(ctx, nil)
+			_, err = tx.SaveEvent(ctx, nil)
 			Expect(err).Should(HaveOccurred())
 		})
 	})

--- a/persistence/provider/memory/eventstore.go
+++ b/persistence/provider/memory/eventstore.go
@@ -8,12 +8,12 @@ import (
 	"github.com/dogmatiq/infix/persistence/subsystem/eventstore"
 )
 
-// SaveEvents persists events in the application's event store.
+// SaveEvent persists an event in the application's event store.
 //
-// It returns the next free offset in the store.
-func (t *transaction) SaveEvents(
+// It returns the event's offset.
+func (t *transaction) SaveEvent(
 	ctx context.Context,
-	envelopes []*envelopespec.Envelope,
+	env *envelopespec.Envelope,
 ) (eventstore.Offset, error) {
 	if err := t.begin(ctx); err != nil {
 		return 0, err
@@ -23,17 +23,13 @@ func (t *transaction) SaveEvents(
 		len(t.ds.db.events) + len(t.uncommitted.events),
 	)
 
-	for _, env := range envelopes {
-		t.uncommitted.events = append(
-			t.uncommitted.events,
-			&eventstore.Event{
-				Offset:   next,
-				Envelope: cloneEnvelope(env),
-			},
-		)
-
-		next++
-	}
+	t.uncommitted.events = append(
+		t.uncommitted.events,
+		&eventstore.Event{
+			Offset:   next,
+			Envelope: cloneEnvelope(env),
+		},
+	)
 
 	return next, nil
 }

--- a/persistence/provider/sql/mysql/schema.go
+++ b/persistence/provider/sql/mysql/schema.go
@@ -40,7 +40,7 @@ func createEventStoreSchema(ctx context.Context, db *sql.DB) {
 		db,
 		`CREATE TABLE event_offset (
 			source_app_key VARBINARY(255) NOT NULL PRIMARY KEY,
-			next_offset    BIGINT NOT NULL
+			next_offset    BIGINT NOT NULL DEFAULT 1
 		) ENGINE=InnoDB`,
 	)
 

--- a/persistence/provider/sql/postgres/error.go
+++ b/persistence/provider/sql/postgres/error.go
@@ -76,19 +76,18 @@ func (d errorConverter) UpdateNextOffset(
 	ctx context.Context,
 	tx *sql.Tx,
 	ak string,
-	n eventstore.Offset,
 ) (eventstore.Offset, error) {
-	o, err := d.d.UpdateNextOffset(ctx, tx, ak, n)
+	o, err := d.d.UpdateNextOffset(ctx, tx, ak)
 	return o, convertContextErrors(ctx, err)
 }
 
-func (d errorConverter) InsertEvents(
+func (d errorConverter) InsertEvent(
 	ctx context.Context,
 	tx *sql.Tx,
 	o eventstore.Offset,
-	envelopes []*envelopespec.Envelope,
+	env *envelopespec.Envelope,
 ) error {
-	err := d.d.InsertEvents(ctx, tx, o, envelopes)
+	err := d.d.InsertEvent(ctx, tx, o, env)
 	return convertContextErrors(ctx, err)
 }
 

--- a/persistence/provider/sql/postgres/eventstore.go
+++ b/persistence/provider/sql/postgres/eventstore.go
@@ -10,13 +10,12 @@ import (
 	"github.com/dogmatiq/infix/persistence/subsystem/eventstore"
 )
 
-// UpdateNextOffset increments the eventstore offset by n and returns the new
+// UpdateNextOffset increments the eventstore offset by 1 and returns the new
 // value.
 func (driver) UpdateNextOffset(
 	ctx context.Context,
 	tx *sql.Tx,
 	ak string,
-	n eventstore.Offset,
 ) (_ eventstore.Offset, err error) {
 	defer sqlx.Recover(&err)
 
@@ -24,34 +23,28 @@ func (driver) UpdateNextOffset(
 		ctx,
 		tx,
 		`INSERT INTO infix.event_offset AS o (
-			source_app_key,
-			next_offset
+			source_app_key
 		) VALUES (
-			$1, $2
+			$1
 		) ON CONFLICT (source_app_key) DO UPDATE SET
-			next_offset = o.next_offset + excluded.next_offset
+			next_offset = o.next_offset + 1
 		RETURNING next_offset`,
 		ak,
-		n,
 	)
 
 	return eventstore.Offset(o), nil
 }
 
-// InsertEvents saves events to the eventstore, starting at a specific offset.
-func (driver) InsertEvents(
+// InsertEvent saves an event to the eventstore at a specific offset.
+func (driver) InsertEvent(
 	ctx context.Context,
 	tx *sql.Tx,
 	o eventstore.Offset,
-	envelopes []*envelopespec.Envelope,
-) (err error) {
-	defer sqlx.Recover(&err)
-
-	for _, env := range envelopes {
-		sqlx.Exec(
-			ctx,
-			tx,
-			`INSERT INTO infix.event (
+	env *envelopespec.Envelope,
+) error {
+	_, err := tx.ExecContext(
+		ctx,
+		`INSERT INTO infix.event (
 				"offset",
 				message_id,
 				causation_id,
@@ -68,25 +61,22 @@ func (driver) InsertEvents(
 			) VALUES (
 				$1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13
 			)`,
-			o,
-			env.MetaData.MessageId,
-			env.MetaData.CausationId,
-			env.MetaData.CorrelationId,
-			env.MetaData.Source.Application.Name,
-			env.MetaData.Source.Application.Key,
-			env.MetaData.Source.Handler.Name,
-			env.MetaData.Source.Handler.Key,
-			env.MetaData.Source.InstanceId,
-			env.MetaData.CreatedAt,
-			env.PortableName,
-			env.MediaType,
-			env.Data,
-		)
+		o,
+		env.MetaData.MessageId,
+		env.MetaData.CausationId,
+		env.MetaData.CorrelationId,
+		env.MetaData.Source.Application.Name,
+		env.MetaData.Source.Application.Key,
+		env.MetaData.Source.Handler.Name,
+		env.MetaData.Source.Handler.Key,
+		env.MetaData.Source.InstanceId,
+		env.MetaData.CreatedAt,
+		env.PortableName,
+		env.MediaType,
+		env.Data,
+	)
 
-		o++
-	}
-
-	return nil
+	return err
 }
 
 // InsertEventFilter inserts a filter that limits selected events to those with

--- a/persistence/provider/sql/postgres/schema.go
+++ b/persistence/provider/sql/postgres/schema.go
@@ -45,7 +45,7 @@ func createEventStoreSchema(ctx context.Context, db *sql.DB) {
 		db,
 		`CREATE TABLE infix.event_offset (
 			source_app_key TEXT NOT NULL PRIMARY KEY,
-			next_offset    BIGINT NOT NULL
+			next_offset    BIGINT NOT NULL DEFAULT 1
 		)`,
 	)
 

--- a/persistence/provider/sql/sqlite/schema.go
+++ b/persistence/provider/sql/sqlite/schema.go
@@ -53,7 +53,7 @@ func createEventStoreSchema(ctx context.Context, db *sql.DB) {
 		db,
 		`CREATE TABLE event_offset (
 			source_app_key TEXT NOT NULL PRIMARY KEY,
-			next_offset    INTEGER NOT NULL
+			next_offset    INTEGER NOT NULL DEFAULT 1
 		) WITHOUT ROWID`,
 	)
 

--- a/persistence/subsystem/eventstore/transaction.go
+++ b/persistence/subsystem/eventstore/transaction.go
@@ -9,11 +9,11 @@ import (
 // Transaction defines the primitive persistence operations for manipulating the
 // event store.
 type Transaction interface {
-	// SaveEvents persists events in the application's event store.
+	// SaveEvent persists an event in the application's event store.
 	//
-	// It returns the next free offset in the store.
-	SaveEvents(
+	// It returns the event's offset.
+	SaveEvent(
 		ctx context.Context,
-		envelopes []*envelopespec.Envelope,
+		env *envelopespec.Envelope,
 	) (Offset, error)
 }


### PR DESCRIPTION
This allows us to have a more meaningful signature, as the function now returns offset of the saved event, rather than the offset after the saved events.