### PR TITLE
Command executor.

### DIFF
--- a/app.go
+++ b/app.go
@@ -6,108 +6,74 @@ import (
 	"github.com/dogmatiq/configkit"
 	"github.com/dogmatiq/configkit/message"
 	"github.com/dogmatiq/dodeca/logging"
+	"github.com/dogmatiq/infix/envelope"
 	"github.com/dogmatiq/infix/eventstream"
-	"github.com/dogmatiq/infix/internal/x/loggingx"
-	"github.com/dogmatiq/infix/projection"
-	"golang.org/x/sync/errgroup"
+	"github.com/dogmatiq/infix/queue"
 )
 
-func (e *Engine) runApplication(
+type app struct {
+	Config         configkit.RichApplication
+	Stream         *eventstream.PersistedStream
+	Queue          *queue.Queue
+	InternalPacker *envelope.Packer
+	ExternalPacker *envelope.Packer
+}
+
+func (e *Engine) initApp(
 	ctx context.Context,
 	cfg configkit.RichApplication,
 ) error {
 	logging.Log(
 		e.logger,
-		"starting @%s application, identity key is %s",
+		"initializing @%s application, identity key is %s",
 		cfg.Identity().Name,
 		cfg.Identity().Key,
 	)
 
-	ds, err := e.dataStores.Get(ctx, cfg.Identity().Key)
+	id := cfg.Identity()
+
+	ds, err := e.dataStores.Get(ctx, id.Key)
 	if err != nil {
 		return err
 	}
 
-	return e.streamEvents(
-		ctx,
-		cfg,
-		// TODO: https://github.com/dogmatiq/infix/issues/76
-		// Make pre-fetch buffer size configurable.
-		&eventstream.PersistedStream{
+	commands := cfg.MessageTypes().Consumed.FilterByRole(message.CommandRole)
+
+	a := &app{
+		Config: cfg,
+		Stream: &eventstream.PersistedStream{
 			App:        cfg.Identity(),
 			Types:      cfg.MessageTypes().Produced.FilterByRole(message.EventRole),
 			Repository: ds.EventStoreRepository(),
 			Marshaler:  e.opts.Marshaler,
-			PreFetch:   10,
+			// TODO: https://github.com/dogmatiq/infix/issues/76
+			// Make pre-fetch buffer size configurable.
+			PreFetch: 10,
 		},
-	)
-}
-
-func (e *Engine) streamEvents(
-	ctx context.Context,
-	source configkit.Application,
-	stream eventstream.Stream,
-) error {
-	g, ctx := errgroup.WithContext(ctx)
-
-	for _, target := range e.opts.AppConfigs {
-		target := target // capture loop variable
-
-		for _, cfg := range target.RichHandlers().Projections() {
-			cfg := cfg // capture loop variable
-
-			g.Go(func() error {
-				return e.streamEventsToProjection(
-					ctx,
-					target,
-					source,
-					stream,
-					cfg,
-				)
-			})
-		}
-	}
-
-	return g.Wait()
-}
-
-func (e *Engine) streamEventsToProjection(
-	ctx context.Context,
-	target configkit.Application,
-	source configkit.Application,
-	stream eventstream.Stream,
-	cfg configkit.RichProjection,
-) error {
-	var logger logging.Logger
-
-	if target.Identity() == source.Identity() {
-		logger = loggingx.WithPrefix(
-			e.opts.Logger,
-			"@%s | stream -> %s | ",
-			target.Identity().Name,
-			cfg.Identity().Name,
-		)
-	} else {
-		logger = loggingx.WithPrefix(
-			e.opts.Logger,
-			"@%s | stream@%s -> %s | ",
-			target.Identity().Name,
-			source.Identity().Name,
-			cfg.Identity().Name,
-		)
-	}
-
-	c := &eventstream.Consumer{
-		Stream:     stream,
-		EventTypes: cfg.MessageTypes().Consumed,
-		Handler: &projection.StreamAdaptor{
-			Handler:        cfg.Handler(),
-			DefaultTimeout: e.opts.MessageTimeout,
-			Logger:         logger,
+		Queue: &queue.Queue{
+			DataStore: ds,
+			Marshaler: e.opts.Marshaler,
 		},
-		BackoffStrategy: e.opts.MessageBackoff,
-		Logger:          logger,
+		InternalPacker: &envelope.Packer{
+			Application: id,
+			Roles:       cfg.MessageTypes().Produced,
+		},
+		ExternalPacker: &envelope.Packer{
+			Application: id,
+			Roles:       commands,
+		},
 	}
 
-	return c.Run(ctx)
+	if e.appsByKey == nil {
+		e.appsByKey = map[string]*app{}
+		e.appsByCommand = map[message.Type]*app{}
+	}
+
+	e.appsByKey[id.Key] = a
+
+	for mt := range commands {
+		e.appsByCommand[mt] = a
+	}
+
+	return nil
 }

--- a/cmd/bank/ui/input.go
+++ b/cmd/bank/ui/input.go
@@ -1,0 +1,106 @@
+package ui
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+)
+
+var reader = bufio.NewReader(os.Stdin)
+
+func (ui *UI) read() string {
+	text, _ := reader.ReadString('\n')
+	text = strings.TrimSpace(text)
+	return text
+}
+
+func (ui *UI) printPrompt() bool {
+	ui.m.Lock()
+	n := len(ui.log)
+	ui.m.Unlock()
+
+	if n == 0 {
+		ui.print("   > ")
+	} else {
+		ui.print("%2d > ", n)
+	}
+
+	return len(ui.log) > 0
+}
+
+func (ui *UI) askText(prompt string) (string, bool) {
+	ui.println("   %s (enter = cancel)", prompt)
+	ui.printPrompt()
+
+	v := ui.read()
+	ui.println("")
+
+	return v, v != ""
+}
+
+func (ui *UI) askTextWithDefault(prompt, def string) string {
+	ui.println("   %s (enter = %#v)", prompt, def)
+	ui.printPrompt()
+
+	v := ui.read()
+	ui.println("")
+
+	if v == "" {
+		return def
+	}
+
+	return v
+}
+
+type item struct {
+	key  interface{}
+	desc string
+	next state
+}
+
+func (ui *UI) askMenu(items ...item) (state, error) {
+	items = append(items, item{"q", "quit", nil})
+	states := map[string]state{}
+
+	var options string
+
+	for _, it := range items {
+		k := fmt.Sprintf("%s", it.key)
+		states[k] = it.next
+		options += fmt.Sprintf("   %s) %s\n", k, it.desc)
+	}
+
+	for {
+		ui.println(" Select an option …")
+		ui.println("")
+		ui.println(options)
+
+		for {
+			ui.printPrompt()
+
+			v := ui.read()
+
+			if v == "" {
+				if ui.flushLog() {
+					break
+				}
+
+				continue
+			}
+
+			if v == "?" {
+				ui.println("")
+				ui.println(options)
+				continue
+			}
+
+			if s, ok := states[v]; ok {
+				ui.println("")
+				return s, nil
+			}
+
+			ui.println("     unrecognised option (%s), use ? to see the valid options", v)
+		}
+	}
+}

--- a/cmd/bank/ui/input.go
+++ b/cmd/bank/ui/input.go
@@ -76,7 +76,7 @@ func (ui *UI) askTextRaw() string {
 			ui.println("   /help  display a help message")
 			ui.println("")
 		default:
-			ui.println("     unrecognised command, try /help")
+			ui.println("     unrecognized command, try /help")
 			ui.println("")
 		}
 	}
@@ -124,7 +124,7 @@ func (ui *UI) askMenu(items ...item) (state, error) {
 				ui.println("")
 				ui.println(options)
 			} else {
-				ui.println("     unrecognised option, try ? and /help")
+				ui.println("     unrecognized option, try ? and /help")
 				ui.println("")
 			}
 		}

--- a/cmd/bank/ui/log.go
+++ b/cmd/bank/ui/log.go
@@ -1,0 +1,32 @@
+package ui
+
+import (
+	"fmt"
+)
+
+// Log writes an application log message formatted according to a format
+// specifier.
+func (ui *UI) Log(f string, v ...interface{}) {
+	ui.LogString(fmt.Sprintf(f, v...))
+}
+
+// LogString writes a pre-formatted application log message.
+func (ui *UI) LogString(s string) {
+	ui.appendLog(s)
+}
+
+// Debug writes a debug log message formatted according to a format
+// specifier.
+func (ui *UI) Debug(f string, v ...interface{}) {
+	ui.DebugString(fmt.Sprintf(f, v...))
+}
+
+// DebugString writes a pre-formatted debug log message.
+func (ui *UI) DebugString(s string) {
+	ui.LogString(s)
+}
+
+// IsDebug returns true if this logger will perform debug logging.
+func (ui *UI) IsDebug() bool {
+	return true
+}

--- a/cmd/bank/ui/output.go
+++ b/cmd/bank/ui/output.go
@@ -1,0 +1,77 @@
+package ui
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+func (ui *UI) banner(f string, v ...interface{}) {
+	text := fmt.Sprintf(
+		"██████  DOGMA BANK • %s  ██",
+		fmt.Sprintf(f, v...),
+	)
+
+	if n := 100 - len(text); n > 0 {
+		text += strings.Repeat("█", n)
+	}
+
+	text += fmt.Sprintf(
+		"  %s  ████████▓▓▓▒▒░",
+		time.Now().Format("3:04:05 PM"),
+	)
+
+	ui.println(strings.ToUpper(text))
+	ui.println("")
+
+	if !ui.flushLog() {
+		ui.println("")
+	}
+}
+
+func (ui *UI) print(f string, v ...interface{}) {
+	fmt.Printf(f, v...)
+}
+
+func (ui *UI) println(f string, v ...interface{}) {
+	fmt.Printf(f+"\n", v...)
+}
+
+func (ui *UI) appendLog(s string) {
+	ui.m.Lock()
+	defer ui.m.Unlock()
+
+	ui.log = append(
+		ui.log,
+		fmt.Sprintf(
+			"%s   %s",
+			time.Now().Format("3:04:05 PM"),
+			s,
+		),
+	)
+}
+
+func (ui *UI) flushLog() bool {
+	ui.m.Lock()
+	log := ui.log
+	ui.log = nil
+	ui.m.Unlock()
+
+	if len(log) == 0 {
+		return false
+	}
+
+	ui.println("")
+	ui.println("   ╭───┤ ENGINE LOG ├────────────────────────────────────────── ─── ── ─")
+	ui.println("   │")
+
+	for _, m := range log {
+		ui.println("   │  %s", m)
+	}
+
+	ui.println("   │")
+	ui.println("   ╰──────────────────────────────────────────── ─── ── ─")
+	ui.println("")
+
+	return true
+}

--- a/cmd/bank/ui/ui.go
+++ b/cmd/bank/ui/ui.go
@@ -1,0 +1,71 @@
+package ui
+
+import (
+	"context"
+	"database/sql"
+	"sync"
+
+	"github.com/dogmatiq/example/messages/commands"
+	"github.com/google/uuid"
+
+	"github.com/dogmatiq/dogma"
+)
+
+type state func(ctx context.Context) (state, error)
+
+// UI manages the states of the user interface.
+type UI struct {
+	DB       *sql.DB
+	Executor dogma.CommandExecutor
+
+	m   sync.Mutex
+	log []string
+}
+
+// Run starts the UI.
+func (ui *UI) Run(ctx context.Context) error {
+	ui.println("")
+
+	var err error
+	st := ui.main
+
+	for st != nil && err == nil {
+		st, err = st(ctx)
+	}
+
+	return err
+}
+
+func (ui *UI) execute(ctx context.Context, m dogma.Message) {
+	if err := ui.Executor.ExecuteCommand(ctx, m); err != nil {
+		ui.appendLog(err.Error())
+	}
+}
+
+func (ui *UI) main(ctx context.Context) (state, error) {
+	ui.banner("MAIN MENU")
+
+	return ui.askMenu(
+		item{"n", "open an account for a new customer", ui.openAccountForNewCustomer},
+	)
+}
+
+func (ui *UI) openAccountForNewCustomer(ctx context.Context) (state, error) {
+	ui.banner("OPEN ACCOUNT (NEW CUSTOMER)")
+
+	cname, ok := ui.askText("Customer Name")
+	if !ok {
+		return ui.main, nil
+	}
+
+	aname := ui.askTextWithDefault("Account Name", "Savings")
+
+	ui.execute(ctx, commands.OpenAccountForNewCustomer{
+		CustomerID:   uuid.New().String(),
+		CustomerName: cname,
+		AccountID:    uuid.New().String(),
+		AccountName:  aname,
+	})
+
+	return ui.main, nil
+}

--- a/cmd/bank/ui/ui.go
+++ b/cmd/bank/ui/ui.go
@@ -24,6 +24,13 @@ type UI struct {
 
 // Run starts the UI.
 func (ui *UI) Run(ctx context.Context) error {
+	defer func() {
+		r := recover()
+		if r != "quit" && r != nil {
+			panic(r)
+		}
+	}()
+
 	ui.println("")
 
 	var err error
@@ -34,6 +41,10 @@ func (ui *UI) Run(ctx context.Context) error {
 	}
 
 	return err
+}
+
+func (ui *UI) quit() {
+	panic("quit")
 }
 
 func (ui *UI) execute(ctx context.Context, m dogma.Message) {
@@ -47,6 +58,7 @@ func (ui *UI) main(ctx context.Context) (state, error) {
 
 	return ui.askMenu(
 		item{"n", "open an account for a new customer", ui.openAccountForNewCustomer},
+		item{"q", "quit", nil},
 	)
 }
 

--- a/draftspecs/messagingspec/error.pb.go
+++ b/draftspecs/messagingspec/error.pb.go
@@ -21,7 +21,7 @@ var _ = math.Inf
 const _ = proto.ProtoPackageIsVersion3 // please upgrade the proto package
 
 // UnrecognizedApplication is an error-details value for INVALID_ARGUMENT
-// errors that occurred because a specific application key was not recognised by
+// errors that occurred because a specific application key was not recognized by
 // the server.
 type UnrecognizedApplication struct {
 	// ApplicationKey is the identity of the application that produced the error.
@@ -64,7 +64,7 @@ func (m *UnrecognizedApplication) GetApplicationKey() string {
 }
 
 // UnrecognizedMessage is an error-details value for INVALID_ARGUMENT errors
-// that occurred because a specific message type was not recognised by the
+// that occurred because a specific message type was not recognized by the
 // server.
 type UnrecognizedMessage struct {
 	// Name is the name of the message type.

--- a/draftspecs/messagingspec/error.proto
+++ b/draftspecs/messagingspec/error.proto
@@ -4,7 +4,7 @@ package dogma.messaging.v1;
 option go_package = "github.com/dogmatiq/infix/draftspecs/messagingspec";
 
 // UnrecognizedApplication is an error-details value for INVALID_ARGUMENT
-// errors that occurred because a specific application key was not recognised by
+// errors that occurred because a specific application key was not recognized by
 // the server.
 message UnrecognizedApplication {
   // ApplicationKey is the identity of the application that produced the error.
@@ -12,7 +12,7 @@ message UnrecognizedApplication {
 }
 
 // UnrecognizedMessage is an error-details value for INVALID_ARGUMENT errors
-// that occurred because a specific message type was not recognised by the
+// that occurred because a specific message type was not recognized by the
 // server.
 message UnrecognizedMessage {
   // Name is the name of the message type.

--- a/engine.go
+++ b/engine.go
@@ -2,11 +2,14 @@ package infix
 
 import (
 	"context"
+	"fmt"
 
+	"github.com/dogmatiq/configkit/message"
 	"github.com/dogmatiq/dodeca/logging"
 	"github.com/dogmatiq/dogma"
 	"github.com/dogmatiq/infix/internal/x/loggingx"
 	"github.com/dogmatiq/infix/persistence"
+	"github.com/dogmatiq/infix/semaphore"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -14,7 +17,12 @@ import (
 type Engine struct {
 	opts       *engineOptions
 	dataStores *persistence.DataStoreSet
+	semaphore  semaphore.Semaphore // TODO: make size configurable
 	logger     logging.Logger
+
+	appsByKey     map[string]*app
+	appsByCommand map[message.Type]*app
+	ready         chan struct{}
 }
 
 // New returns a new engine that hosts the given application.
@@ -37,13 +45,46 @@ func New(app dogma.Application, options ...EngineOption) *Engine {
 			opts.Logger,
 			"engine | ",
 		),
+		ready: make(chan struct{}),
 	}
+}
+
+// ExecuteCommand enqueues a command for execution.
+func (e *Engine) ExecuteCommand(ctx context.Context, m dogma.Message) error {
+	select {
+	case <-e.ready:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+
+	mt := message.TypeOf(m)
+
+	a, ok := e.appsByCommand[mt]
+	if !ok {
+		return fmt.Errorf("no application accepts %s commands", mt)
+	}
+
+	env := a.ExternalPacker.PackCommand(m)
+
+	return a.Queue.Enqueue(ctx, env)
 }
 
 // Run hosts the given application until ctx is canceled or an error occurs.
 func (e *Engine) Run(ctx context.Context) error {
 	defer e.dataStores.Close()
 
+	for _, cfg := range e.opts.AppConfigs {
+		if err := e.initApp(ctx, cfg); err != nil {
+			return err
+		}
+	}
+
+	close(e.ready)
+
+	return e.run(ctx)
+}
+
+func (e *Engine) run(ctx context.Context) error {
 	parent := ctx
 	g, ctx := errgroup.WithContext(ctx)
 
@@ -57,11 +98,16 @@ func (e *Engine) Run(ctx context.Context) error {
 		})
 	}
 
-	for _, cfg := range e.opts.AppConfigs {
-		cfg := cfg // capture loop variable
+	for _, a := range e.appsByKey {
+		a := a // capture loop variable
 
 		g.Go(func() error {
-			return e.runApplication(ctx, cfg)
+			// TODO: start queue consumer
+			return nil
+		})
+
+		g.Go(func() error {
+			return e.consumeStream(ctx, a.Stream)
 		})
 	}
 

--- a/engine_test.go
+++ b/engine_test.go
@@ -1,0 +1,8 @@
+package infix_test
+
+import (
+	"github.com/dogmatiq/dogma"
+	. "github.com/dogmatiq/infix"
+)
+
+var _ dogma.CommandExecutor = (*Engine)(nil)

--- a/eventstream.go
+++ b/eventstream.go
@@ -1,0 +1,89 @@
+package infix
+
+import (
+	"context"
+
+	"github.com/dogmatiq/configkit"
+	"github.com/dogmatiq/dodeca/logging"
+	"github.com/dogmatiq/infix/eventstream"
+	"github.com/dogmatiq/infix/internal/x/loggingx"
+	"github.com/dogmatiq/infix/projection"
+	"golang.org/x/sync/errgroup"
+)
+
+// consumeStream starts any consumers that need to consume from s across all
+// hosted applications.
+func (e *Engine) consumeStream(ctx context.Context, s eventstream.Stream) error {
+	g, ctx := errgroup.WithContext(ctx)
+
+	for _, a := range e.appsByKey {
+		a := a // capture loop variable
+		g.Go(func() error {
+			return e.consumeStreamForApp(ctx, s, a.Config)
+		})
+	}
+
+	return g.Wait()
+}
+
+// consumeStreamForApp starts any consumers that need to consume from s for a
+// specific application.
+func (e *Engine) consumeStreamForApp(
+	ctx context.Context,
+	s eventstream.Stream,
+	a configkit.RichApplication,
+) error {
+	g, ctx := errgroup.WithContext(ctx)
+
+	for _, h := range a.RichHandlers().Projections() {
+		h := h // capture loop variable
+		g.Go(func() error {
+			return e.consumeStreamForProjection(ctx, s, a, h)
+		})
+	}
+
+	return g.Wait()
+}
+
+// consumeStreamForApp starts any consumers that need to consume from s for a
+// specific projection message handlers.
+func (e *Engine) consumeStreamForProjection(
+	ctx context.Context,
+	s eventstream.Stream,
+	a configkit.RichApplication,
+	h configkit.RichProjection,
+) error {
+	var logger logging.Logger
+
+	if a.Identity() == s.Application() {
+		logger = loggingx.WithPrefix(
+			e.opts.Logger,
+			"@%s | stream -> %s | ",
+			a.Identity().Name,
+			h.Identity().Name,
+		)
+	} else {
+		logger = loggingx.WithPrefix(
+			e.opts.Logger,
+			"@%s | stream@%s -> %s | ",
+			a.Identity().Name,
+			s.Application().Name,
+			h.Identity().Name,
+		)
+	}
+
+	c := &eventstream.Consumer{
+		Stream:     s,
+		EventTypes: h.MessageTypes().Consumed,
+		Handler: &projection.StreamAdaptor{
+			Handler:        h.Handler(),
+			DefaultTimeout: e.opts.MessageTimeout,
+			Logger:         logger,
+		},
+		Semaphore:       e.semaphore,
+		BackoffStrategy: e.opts.MessageBackoff,
+		Logger:          logger,
+	}
+
+	return c.Run(ctx)
+}

--- a/eventstream/networkserver_test.go
+++ b/eventstream/networkserver_test.go
@@ -215,7 +215,7 @@ var _ = Describe("type server", func() {
 			Expect(s.Code()).To(Equal(codes.InvalidArgument))
 		})
 
-		It("returns an INVALID_ARGUMENT error if the message type collection contains unrecognised messages", func() {
+		It("returns an INVALID_ARGUMENT error if the message type collection contains unrecognized messages", func() {
 			req := &messagingspec.ConsumeRequest{
 				ApplicationKey: "<app-key>",
 				Types:          []string{"<unknown-1>", "<unknown-2>"},

--- a/network.go
+++ b/network.go
@@ -8,7 +8,6 @@ import (
 	"github.com/dogmatiq/configkit"
 	configapi "github.com/dogmatiq/configkit/api"
 	"github.com/dogmatiq/configkit/api/discovery"
-	"github.com/dogmatiq/configkit/message"
 	"github.com/dogmatiq/dodeca/logging"
 	"github.com/dogmatiq/infix/draftspecs/messagingspec"
 	"github.com/dogmatiq/infix/eventstream"
@@ -62,22 +61,8 @@ func (e *Engine) registerConfigServer(ctx context.Context, s *grpc.Server) error
 func (e *Engine) registerEventStreamServer(ctx context.Context, s *grpc.Server) error {
 	streams := map[string]eventstream.Stream{}
 
-	// Create a map of application-key to stream for each hosted application.
-	for _, cfg := range e.opts.AppConfigs {
-		ds, err := e.dataStores.Get(ctx, cfg.Identity().Key)
-		if err != nil {
-			return err
-		}
-
-		// TODO: https://github.com/dogmatiq/infix/issues/76
-		// Make pre-fetch buffer size configurable.
-		streams[cfg.Identity().Key] = &eventstream.PersistedStream{
-			App:        cfg.Identity(),
-			Types:      cfg.MessageTypes().Produced.FilterByRole(message.EventRole),
-			Repository: ds.EventStoreRepository(),
-			Marshaler:  e.opts.Marshaler,
-			PreFetch:   10,
-		}
+	for k, a := range e.appsByKey {
+		streams[k] = a.Stream
 	}
 
 	eventstream.RegisterServer(

--- a/network.go
+++ b/network.go
@@ -98,17 +98,17 @@ func (e *Engine) discover(ctx context.Context) error {
 			logger,
 			&discovery.ApplicationExecutor{
 				Task: func(ctx context.Context, a *discovery.Application) {
-					// TODO: https://github.com/dogmatiq/infix/issues/76
-					// Make pre-fetch buffer size configurable.
 					stream := &eventstream.NetworkStream{
 						App:       a.Identity(),
 						Client:    messagingspec.NewEventStreamClient(a.Client.Connection),
 						Marshaler: e.opts.Marshaler,
-						PreFetch:  10,
+						// TODO: https://github.com/dogmatiq/infix/issues/76
+						// Make pre-fetch buffer size configurable.
+						PreFetch: 10,
 					}
 
 					// err will only ever be context-cancelation
-					_ = e.streamEvents(ctx, a, stream)
+					_ = e.consumeStream(ctx, stream)
 				},
 			},
 		),

--- a/persistence/provider/sql/driver_test.go
+++ b/persistence/provider/sql/driver_test.go
@@ -42,7 +42,7 @@ var _ = Describe("func NewDriver()", func() {
 		),
 	)
 
-	It("returns an error if the driver is unrecognised", func() {
+	It("returns an error if the driver is unrecognized", func() {
 		_, err := NewDriver(sqltest.MockDB())
 		Expect(err).Should(HaveOccurred())
 	})

--- a/queue/doc.go
+++ b/queue/doc.go
@@ -1,0 +1,3 @@
+// Package queue provides abstractions for consuming prioritized queues of
+// messages.
+package queue

--- a/queue/ginkgo_test.go
+++ b/queue/ginkgo_test.go
@@ -1,0 +1,15 @@
+package queue_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
+)
+
+func TestSuite(t *testing.T) {
+	type tag struct{}
+	gomega.RegisterFailHandler(ginkgo.Fail)
+	ginkgo.RunSpecs(t, reflect.TypeOf(tag{}).PkgPath())
+}

--- a/queue/queue.go
+++ b/queue/queue.go
@@ -42,11 +42,7 @@ func (q *Queue) Enqueue(ctx context.Context, env *envelope.Envelope) error {
 		return err
 	}
 
-	if err := tx.Commit(ctx); err != nil {
-		return err
-	}
-
-	return nil
+	return tx.Commit(ctx)
 }
 
 // item is a container for a queued message that is buffered in memory.

--- a/queue/queue.go
+++ b/queue/queue.go
@@ -1,0 +1,59 @@
+package queue
+
+import (
+	"context"
+	"time"
+
+	"github.com/dogmatiq/infix/envelope"
+	"github.com/dogmatiq/infix/persistence"
+	"github.com/dogmatiq/infix/persistence/subsystem/queuestore"
+	"github.com/dogmatiq/marshalkit"
+)
+
+// A Queue is an prioritized collection of messages.
+//
+// It implements the dogma.CommandExecutor interface.
+type Queue struct {
+	DataStore persistence.DataStore
+	Marshaler marshalkit.ValueMarshaler
+}
+
+// Enqueue adds a message to the queue.
+func (q *Queue) Enqueue(ctx context.Context, env *envelope.Envelope) error {
+	it := &item{
+		env: env,
+		message: &queuestore.Message{
+			NextAttemptAt: time.Now(),
+			Envelope:      envelope.MustMarshal(q.Marshaler, env),
+		},
+	}
+
+	tx, err := q.DataStore.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	if err := tx.SaveMessageToQueue(
+		ctx,
+		it.message.Envelope,
+		it.message.NextAttemptAt,
+	); err != nil {
+		return err
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// item is a container for a queued message that is buffered in memory.
+//
+// It keeps the in-memory envelope representation alongside the protocol buffers
+// representation to avoid excess marshaling/unmarshaling.
+type item struct {
+	env     *envelope.Envelope
+	message *queuestore.Message
+}

--- a/queue/queue_test.go
+++ b/queue/queue_test.go
@@ -1,0 +1,84 @@
+package queue_test
+
+import (
+	"context"
+	"time"
+
+	. "github.com/dogmatiq/dogma/fixtures"
+	"github.com/dogmatiq/infix/envelope"
+	. "github.com/dogmatiq/infix/fixtures"
+	"github.com/dogmatiq/infix/persistence"
+	. "github.com/dogmatiq/infix/queue"
+	. "github.com/dogmatiq/marshalkit/fixtures"
+	"github.com/golang/protobuf/proto"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("type Queue", func() {
+	var (
+		ctx       context.Context
+		cancel    context.CancelFunc
+		provider  *PersistenceProvider
+		dataStore persistence.DataStore
+		queue     *Queue
+		env       = NewEnvelope("<id>", MessageA1)
+	)
+
+	BeforeEach(func() {
+		ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
+
+		provider = &PersistenceProvider{}
+
+		var err error
+		dataStore, err = provider.Open(ctx, "<app-key>")
+		Expect(err).ShouldNot(HaveOccurred())
+
+		queue = &Queue{
+			DataStore: dataStore,
+			Marshaler: Marshaler,
+		}
+	})
+
+	AfterEach(func() {
+		if dataStore != nil {
+			dataStore.Close()
+		}
+
+		cancel()
+	})
+
+	Describe("func Enqueue()", func() {
+		It("persists the message in the queue store", func() {
+			err := queue.Enqueue(ctx, env)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			messages, err := dataStore.QueueStoreRepository().LoadQueueMessages(ctx, 2)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(messages).To(HaveLen(1))
+
+			m := messages[0]
+			penv := envelope.MustMarshal(Marshaler, env)
+			Expect(proto.Equal(m.Envelope, penv)).To(BeTrue())
+		})
+
+		It("schedules the message for immediate handling", func() {
+			err := queue.Enqueue(ctx, env)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			messages, err := dataStore.QueueStoreRepository().LoadQueueMessages(ctx, 2)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(messages).To(HaveLen(1))
+
+			m := messages[0]
+			Expect(m.NextAttemptAt).To(BeTemporally("~", time.Now()))
+		})
+
+		It("returns an error if the transaction can not be begun", func() {
+			dataStore.Close()
+
+			err := queue.Enqueue(ctx, env)
+			Expect(err).Should(HaveOccurred())
+		})
+	})
+})


### PR DESCRIPTION
This PR adds the `ExecuteCommand()` method to `Engine`, meaning that it now implements `dogma.CommandExecutor`.

I've also started to add a basic CLI app like Koden's one in dogmatiq/example. I tried to use his as is but it relies on the fact that the test engine is synchronous.