### PR TITLE
Separate session from queue.

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -66,9 +66,7 @@ func (e *Engine) ExecuteCommand(ctx context.Context, m dogma.Message) error {
 		return fmt.Errorf("no application accepts %s commands", mt)
 	}
 
-	env := a.ExternalPacker.PackCommand(m)
-
-	return a.Queue.Push(ctx, env)
+	return a.Executor.ExecuteCommand(ctx, m)
 }
 
 // Run hosts the given application until ctx is canceled or an error occurs.

--- a/fixtures/envelope.go
+++ b/fixtures/envelope.go
@@ -1,9 +1,12 @@
 package fixtures
 
 import (
+	"strconv"
+	"sync"
 	"time"
 
 	"github.com/dogmatiq/configkit"
+	"github.com/dogmatiq/configkit/message"
 	"github.com/dogmatiq/dogma"
 	"github.com/dogmatiq/infix/draftspecs/envelopespec"
 	"github.com/dogmatiq/infix/envelope"
@@ -90,5 +93,41 @@ func cleanseTime(t *time.Time) {
 	err = t.UnmarshalText(data)
 	if err != nil {
 		panic(err)
+	}
+}
+
+// NewPacker returns an envelope packer that uses a deterministic ID sequence
+// and clock.
+//
+// MessageID is a monotonically increasing integer, starting at 0. CreatedAt
+// starts at 2000-01-01 00:00:00 UTC and increases by 1 second for each message.
+func NewPacker(roles message.TypeRoles) *envelope.Packer {
+	var (
+		m   sync.Mutex
+		id  int64
+		now = time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
+	)
+
+	return &envelope.Packer{
+		Application: configkit.MustNewIdentity("<app-name>", "<app-key>"),
+		Roles:       roles,
+		GenerateID: func() string {
+			m.Lock()
+			defer m.Unlock()
+
+			v := strconv.FormatInt(id, 10)
+			id++
+
+			return v
+		},
+		Now: func() time.Time {
+			m.Lock()
+			defer m.Unlock()
+
+			v := now
+			now = now.Add(1 * time.Second)
+
+			return v
+		},
 	}
 }

--- a/queue/consumer_test.go
+++ b/queue/consumer_test.go
@@ -84,8 +84,7 @@ var _ = Describe("type Consumer", func() {
 		})
 
 		It("passes messages to the handler", func() {
-			err := queue.Push(ctx, env0)
-			Expect(err).ShouldNot(HaveOccurred())
+			push(ctx, queue, env0)
 
 			handler.HandleMessageFunc = func(
 				ctx context.Context,
@@ -98,7 +97,7 @@ var _ = Describe("type Consumer", func() {
 				return nil
 			}
 
-			err = consumer.Run(ctx)
+			err := consumer.Run(ctx)
 			Expect(err).To(Equal(context.Canceled))
 		})
 
@@ -108,14 +107,12 @@ var _ = Describe("type Consumer", func() {
 			consumer.BackoffStrategy = backoff.Constant(0)
 
 			// Push a message.
-			err := queue.Push(ctx, env0)
-			Expect(err).ShouldNot(HaveOccurred())
+			push(ctx, queue, env0)
 
 			// Push another message after a delay guaranteeing that they don't
 			// have the same next-attempt time.
 			time.Sleep(5 * time.Millisecond)
-			err = queue.Push(ctx, env1)
-			Expect(err).ShouldNot(HaveOccurred())
+			push(ctx, queue, env1)
 
 			// Then setup a handler that expects to see env0 then env1. If the
 			// session for env0 is not committed we will see it twice before we
@@ -143,7 +140,7 @@ var _ = Describe("type Consumer", func() {
 				return nil
 			}
 
-			err = consumer.Run(ctx)
+			err := consumer.Run(ctx)
 			Expect(err).To(Equal(context.Canceled))
 		})
 
@@ -152,8 +149,7 @@ var _ = Describe("type Consumer", func() {
 			delay := 5 * time.Millisecond
 			consumer.BackoffStrategy = backoff.Constant(delay)
 
-			err := queue.Push(ctx, env0)
-			Expect(err).ShouldNot(HaveOccurred())
+			push(ctx, queue, env0)
 
 			// Then setup a handler that expects to see env0 twice. If the
 			// session for env0 is not rolled back we it will not be retried.
@@ -178,7 +174,7 @@ var _ = Describe("type Consumer", func() {
 				return nil
 			}
 
-			err = consumer.Run(ctx)
+			err := consumer.Run(ctx)
 			Expect(err).To(Equal(context.Canceled))
 
 			handler.HandleMessageFunc = func(
@@ -202,8 +198,7 @@ var _ = Describe("type Consumer", func() {
 				cancel()
 			}()
 
-			err = queue.Push(ctx, env0)
-			Expect(err).ShouldNot(HaveOccurred())
+			push(ctx, queue, env0)
 
 			err = consumer.Run(ctx)
 			Expect(err).To(Equal(context.Canceled))

--- a/queue/consumer_test.go
+++ b/queue/consumer_test.go
@@ -57,14 +57,16 @@ var _ = Describe("type Consumer", func() {
 			Marshaler: Marshaler,
 		}
 
-		go queue.Run(ctx)
-
 		handler = &QueueHandlerStub{}
 
 		consumer = &Consumer{
 			Queue:   queue,
 			Handler: handler,
 		}
+	})
+
+	JustBeforeEach(func() {
+		go queue.Run(ctx)
 	})
 
 	AfterEach(func() {

--- a/queue/executor.go
+++ b/queue/executor.go
@@ -1,0 +1,37 @@
+package queue
+
+import (
+	"context"
+	"time"
+
+	"github.com/dogmatiq/dogma"
+	"github.com/dogmatiq/infix/envelope"
+	"github.com/dogmatiq/infix/persistence"
+)
+
+// CommandExecutor is an implementation of dogma.CommandExecutor that adds
+// commands to the message queue.
+type CommandExecutor struct {
+	Queue  *Queue
+	Packer *envelope.Packer
+}
+
+// ExecuteCommand enqueues a command for execution.
+func (x *CommandExecutor) ExecuteCommand(ctx context.Context, m dogma.Message) error {
+	env := x.Packer.PackCommand(m)
+	qm := x.Queue.NewMessage(env, time.Now())
+
+	if err := persistence.WithTransaction(
+		ctx,
+		x.Queue.DataStore,
+		func(tx persistence.ManagedTransaction) error {
+			return tx.SaveMessageToQueue(ctx, qm)
+		},
+	); err != nil {
+		return err
+	}
+
+	qm.Revision++
+
+	return x.Queue.Track(ctx, env, qm)
+}

--- a/queue/executor_test.go
+++ b/queue/executor_test.go
@@ -1,0 +1,127 @@
+package queue_test
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/dogmatiq/configkit/message"
+	"github.com/dogmatiq/dogma"
+	. "github.com/dogmatiq/dogma/fixtures"
+	"github.com/dogmatiq/infix/draftspecs/envelopespec"
+	. "github.com/dogmatiq/infix/fixtures"
+	"github.com/dogmatiq/infix/persistence"
+	"github.com/dogmatiq/infix/persistence/provider/memory"
+	. "github.com/dogmatiq/infix/queue"
+	. "github.com/dogmatiq/marshalkit/fixtures"
+	"github.com/golang/protobuf/proto"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ dogma.CommandExecutor = (*CommandExecutor)(nil)
+
+var _ = Describe("type Executor", func() {
+	var (
+		ctx       context.Context
+		cancel    context.CancelFunc
+		provider  *ProviderStub
+		dataStore *DataStoreStub
+		queue     *Queue
+		executor  *CommandExecutor
+	)
+
+	BeforeEach(func() {
+		ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
+
+		provider = &ProviderStub{
+			Provider: &memory.Provider{},
+		}
+
+		ds, err := provider.Open(ctx, "<app-key>")
+		Expect(err).ShouldNot(HaveOccurred())
+
+		dataStore = ds.(*DataStoreStub)
+
+		queue = &Queue{
+			DataStore: dataStore,
+			Marshaler: Marshaler,
+		}
+
+		executor = &CommandExecutor{
+			Queue: queue,
+			Packer: NewPacker(
+				message.TypeRoles{
+					message.TypeOf(MessageA{}): message.CommandRole,
+				},
+			),
+		}
+
+		go queue.Run(ctx)
+	})
+
+	AfterEach(func() {
+		if dataStore != nil {
+			dataStore.Close()
+		}
+
+		cancel()
+	})
+
+	Describe("func ExecuteCommand()", func() {
+		It("persists the message in the queue store", func() {
+			err := executor.ExecuteCommand(ctx, MessageA1)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			messages, err := dataStore.QueueStoreRepository().LoadQueueMessages(ctx, 2)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(messages).To(HaveLen(1))
+
+			x := &envelopespec.Envelope{
+				MetaData: &envelopespec.MetaData{
+					MessageId:     "0",
+					CorrelationId: "0",
+					CausationId:   "0",
+					Source: &envelopespec.Source{
+						Application: &envelopespec.Identity{
+							Name: "<app-name>",
+							Key:  "<app-key>",
+						},
+					},
+					CreatedAt: "2000-01-01T00:00:00Z",
+				},
+				PortableName: MessageAPortableName,
+				MediaType:    MessageA1Packet.MediaType,
+				Data:         MessageA1Packet.Data,
+			}
+
+			m := messages[0]
+			if !proto.Equal(m.Envelope, x) {
+				Expect(m.Envelope).To(Equal(x))
+			}
+		})
+
+		It("schedules the message for immediate handling", func() {
+			err := executor.ExecuteCommand(ctx, MessageA1)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			messages, err := dataStore.QueueStoreRepository().LoadQueueMessages(ctx, 2)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(messages).To(HaveLen(1))
+
+			m := messages[0]
+			Expect(m.NextAttemptAt).To(BeTemporally("~", time.Now()))
+		})
+
+		It("returns an error if the transaction can not be begun", func() {
+			dataStore.BeginFunc = func(
+				ctx context.Context,
+			) (persistence.Transaction, error) {
+				return nil, errors.New("<error>")
+			}
+
+			err := executor.ExecuteCommand(ctx, MessageA1)
+			Expect(err).Should(HaveOccurred())
+		})
+	})
+})

--- a/queue/executor_test.go
+++ b/queue/executor_test.go
@@ -56,7 +56,9 @@ var _ = Describe("type Executor", func() {
 				},
 			),
 		}
+	})
 
+	JustBeforeEach(func() {
 		go queue.Run(ctx)
 	})
 

--- a/queue/queue.go
+++ b/queue/queue.go
@@ -56,8 +56,6 @@ type Queue struct {
 	pending    pdeque.Deque        // priority queue of messages without active sessions
 	exhaustive uint32              // atomic tri-bool, see exhaustiveXXX consts.
 
-	started uint32 // atomic bool
-
 	once sync.Once
 	done chan struct{} // closed when Run() exits
 	in   chan *elem    // delivers elements to Run() for tracking
@@ -163,11 +161,6 @@ func (q *Queue) Track(
 // or manually added to the queue by Track().
 func (q *Queue) Run(ctx context.Context) error {
 	q.init()
-
-	if !atomic.CompareAndSwapUint32(&q.started, 0, 1) {
-		panic("queue already started")
-	}
-
 	defer close(q.done)
 
 	for {

--- a/queue/queue.go
+++ b/queue/queue.go
@@ -56,6 +56,8 @@ type Queue struct {
 	pending    pdeque.Deque        // priority queue of messages without active sessions
 	exhaustive uint32              // atomic tri-bool, see exhaustiveXXX consts.
 
+	started uint32 // atomic bool
+
 	once sync.Once
 	done chan struct{} // closed when Run() exits
 	in   chan *elem    // delivers elements to Run() for tracking
@@ -110,24 +112,24 @@ func (q *Queue) Pop(ctx context.Context) (*Session, error) {
 	}
 }
 
-// Push adds a message to the queue.
-func (q *Queue) Push(ctx context.Context, env *envelope.Envelope) error {
-	m := &queuestore.Message{
-		NextAttemptAt: time.Now(),
+// NewMessage returns a new queue store message containing the given envelope.
+func (q *Queue) NewMessage(env *envelope.Envelope, n time.Time) *queuestore.Message {
+	return &queuestore.Message{
+		NextAttemptAt: n,
 		Envelope:      envelope.MustMarshal(q.Marshaler, env),
 	}
+}
 
-	if err := persistence.WithTransaction(
-		ctx,
-		q.DataStore,
-		func(tx persistence.ManagedTransaction) error {
-			return tx.SaveMessageToQueue(ctx, m)
-		},
-	); err != nil {
-		return err
+// Track begins tracking a message that has been persisted to the queue store.
+func (q *Queue) Track(
+	ctx context.Context,
+	env *envelope.Envelope,
+	m *queuestore.Message,
+) error {
+	if m.Revision == 0 {
+		panic("message must be persisted")
 	}
 
-	m.Revision++
 	e := &elem{env: env, message: m}
 
 	q.init()
@@ -139,18 +141,18 @@ func (q *Queue) Push(ctx context.Context, env *envelope.Envelope) error {
 		// Set the exhaustive state to NO so that Run() knows to try loading
 		// messages from the store again.
 		atomic.StoreUint32(&q.exhaustive, exhaustiveNo)
-		logging.Debug(q.Logger, "%s pushed, but canceled before notify (exhaustive: no)", e.message.ID())
+		logging.Debug(q.Logger, "%s requested tracking, but canceled or timed-out(exhaustive: no)", e.message.ID())
 		return ctx.Err()
 
 	case q.in <- e:
-		logging.Debug(q.Logger, "%s pushed", e.message.ID())
+		logging.Debug(q.Logger, "%s requested tracking successfully", e.message.ID())
 		return nil
 
 	case <-q.done:
 		// Run() has stopped, so nothing will be tracked, but the message has
 		// been persisted so from the perspective of the caller the message has
 		// been queued successfully.
-		logging.Debug(q.Logger, "%s pushed, but the queue is not running", e.message.ID())
+		logging.Debug(q.Logger, "%s requested tracking, but the queue is not running", e.message.ID())
 		return nil
 	}
 }
@@ -158,9 +160,14 @@ func (q *Queue) Push(ctx context.Context, env *envelope.Envelope) error {
 // Run starts the queue.
 //
 // It coordinates the tracking of messages that are loaded from the queue store,
-// or added to the queue by Push() or as part of handling another message.
+// or manually added to the queue by Track().
 func (q *Queue) Run(ctx context.Context) error {
 	q.init()
+
+	if !atomic.CompareAndSwapUint32(&q.started, 0, 1) {
+		panic("queue already started")
+	}
+
 	defer close(q.done)
 
 	for {
@@ -258,7 +265,7 @@ func (q *Queue) load(ctx context.Context) error {
 		return nil
 	}
 
-	// We set the status to UNKNOWN while we are loading. If a call to Push()
+	// We set the status to UNKNOWN while we are loading. If a call to Track()
 	// comes along and sets it to NO in the mean-time, we know not to set it
 	// back to YES after we finish loading as we may or may not have that
 	// particular message in the result of the load.
@@ -286,7 +293,7 @@ func (q *Queue) load(ctx context.Context) error {
 		// We didn't get as many messages as we requested, so we know we have
 		// everything in memory.
 		//
-		// Only set the exhaustive status back to YES if a Push() call did not
+		// Only set the exhaustive status back to YES if a Track() call did not
 		// set it to NO while we were loading.
 		logging.Debug(q.Logger, "loaded %d message(s) from store (exhaustive: yes)", n)
 	} else {
@@ -332,9 +339,9 @@ func (q *Queue) update(e *elem) bool {
 	after := len(q.tracked)
 
 	if before == after {
-		// The message was already be in the tracked list, which can occur if it was
-		// pushed just before we loaded form the store so we see the message both in
-		// the load result and on the q.in channel.
+		// The message was already be in the tracked list, which can occur if it
+		// was persisted just before we loaded form the store so we see the
+		// message both in the load result and on the q.in channel.
 		logging.Debug(q.Logger, "%s is already tracked (pending: %d, tracked: %d/%d)", e.message.ID(), q.pending.Len(), len(q.tracked), limit)
 		return false
 	}
@@ -388,7 +395,7 @@ func (q *Queue) init() {
 		// Allocate capcity for our limit +1 element used to detect overflow.
 		q.tracked = make(map[string]struct{}, limit+1)
 
-		// Buffered to avoid blocking in Push(), doesn't *need* to be == limit.
+		// Buffered to avoid blocking in Track(), doesn't *need* to be == limit.
 		q.in = make(chan *elem, limit)
 
 		q.done = make(chan struct{})

--- a/queue/queue_test.go
+++ b/queue/queue_test.go
@@ -11,12 +11,42 @@ import (
 	"github.com/dogmatiq/infix/persistence"
 	"github.com/dogmatiq/infix/persistence/provider/memory"
 	"github.com/dogmatiq/infix/persistence/subsystem/queuestore"
+	"github.com/dogmatiq/infix/queue"
 	. "github.com/dogmatiq/infix/queue"
 	. "github.com/dogmatiq/marshalkit/fixtures"
-	"github.com/golang/protobuf/proto"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
+
+// push is a helper function for testing the queue that persists a message to
+// the queue then begins tracking it.
+func push(
+	ctx context.Context,
+	q *queue.Queue,
+	env *envelope.Envelope,
+	nextOptional ...time.Time,
+) {
+	next := time.Now()
+	for _, n := range nextOptional {
+		next = n
+	}
+
+	m := q.NewMessage(env, next)
+
+	err := persistence.WithTransaction(
+		ctx,
+		q.DataStore,
+		func(tx persistence.ManagedTransaction) error {
+			return tx.SaveMessageToQueue(ctx, m)
+		},
+	)
+	Expect(err).ShouldNot(HaveOccurred())
+
+	m.Revision++
+
+	err = q.Track(ctx, env, m)
+	Expect(err).ShouldNot(HaveOccurred())
+}
 
 var _ = Describe("type Queue", func() {
 	var (
@@ -66,7 +96,13 @@ var _ = Describe("type Queue", func() {
 
 	When("the queue is running", func() {
 		BeforeEach(func() {
-			go queue.Run(ctx)
+			q := queue
+
+			go func() {
+				defer GinkgoRecover()
+				err := q.Run(ctx)
+				Expect(err).To(Equal(context.Canceled))
+			}()
 		})
 
 		Describe("func Pop()", func() {
@@ -75,8 +111,7 @@ var _ = Describe("type Queue", func() {
 					go func() {
 						defer GinkgoRecover()
 						time.Sleep(20 * time.Millisecond)
-						err := queue.Push(ctx, env0)
-						Expect(err).ShouldNot(HaveOccurred())
+						push(ctx, queue, env0)
 					}()
 
 					sess, err := queue.Pop(ctx)
@@ -97,13 +132,12 @@ var _ = Describe("type Queue", func() {
 			})
 
 			When("the queue is not empty", func() {
-				BeforeEach(func() {
-					err := queue.Push(ctx, env0)
-					Expect(err).ShouldNot(HaveOccurred())
-				})
-
 				When("the message at the front of the queue is ready for handling", func() {
-					It("returns immediately", func() {
+					BeforeEach(func() {
+						push(ctx, queue, env0)
+					})
+
+					It("returns a session immediately", func() {
 						ctx, cancel := context.WithTimeout(ctx, 5*time.Millisecond)
 						defer cancel()
 
@@ -118,13 +152,7 @@ var _ = Describe("type Queue", func() {
 
 					BeforeEach(func() {
 						next = time.Now().Add(10 * time.Millisecond)
-
-						sess, err := queue.Pop(ctx)
-						Expect(err).ShouldNot(HaveOccurred())
-						defer sess.Close()
-
-						err = sess.Rollback(ctx, next)
-						Expect(err).ShouldNot(HaveOccurred())
+						push(ctx, queue, env0, next)
 					})
 
 					It("blocks until the message becomes ready", func() {
@@ -139,8 +167,7 @@ var _ = Describe("type Queue", func() {
 						go func() {
 							defer GinkgoRecover()
 							time.Sleep(5 * time.Millisecond)
-							err := queue.Push(ctx, env1)
-							Expect(err).ShouldNot(HaveOccurred())
+							push(ctx, queue, env1)
 						}()
 
 						sess, err := queue.Pop(ctx)
@@ -205,61 +232,37 @@ var _ = Describe("type Queue", func() {
 			})
 		})
 
-		Describe("func Push()", func() {
-			It("persists the message in the queue store", func() {
-				err := queue.Push(ctx, env0)
-				Expect(err).ShouldNot(HaveOccurred())
-
-				messages, err := dataStore.QueueStoreRepository().LoadQueueMessages(ctx, 2)
-				Expect(err).ShouldNot(HaveOccurred())
-				Expect(messages).To(HaveLen(1))
-
-				m := messages[0]
-				penv := envelope.MustMarshal(Marshaler, env0)
-				Expect(proto.Equal(m.Envelope, penv)).To(BeTrue())
-			})
-
-			It("schedules the message for immediate handling", func() {
-				err := queue.Push(ctx, env0)
-				Expect(err).ShouldNot(HaveOccurred())
-
-				messages, err := dataStore.QueueStoreRepository().LoadQueueMessages(ctx, 2)
-				Expect(err).ShouldNot(HaveOccurred())
-				Expect(messages).To(HaveLen(1))
-
-				m := messages[0]
-				Expect(m.NextAttemptAt).To(BeTemporally("~", time.Now()))
-			})
-
-			It("returns an error if the transaction can not be begun", func() {
-				dataStore.BeginFunc = func(
-					ctx context.Context,
-				) (persistence.Transaction, error) {
-					return nil, errors.New("<error>")
-				}
-
-				err := queue.Push(ctx, env0)
-				Expect(err).Should(HaveOccurred())
+		Describe("func Track()", func() {
+			It("panics if the message has not been persisted", func() {
+				Expect(func() {
+					queue.Track(
+						ctx,
+						env0,
+						&queuestore.Message{
+							Revision: 0,
+						},
+					)
+				}).To(Panic())
 			})
 
 			It("discards an element if the buffer is full", func() {
 				queue.BufferSize = 1
 
-				err := queue.Push(ctx, env0)
-				Expect(err).ShouldNot(HaveOccurred())
+				// This push fills the buffer.
+				push(ctx, queue, env0)
 
 				// This push exceeds the limit so env1 should not be buffered.
-				err = queue.Push(ctx, env1)
-				Expect(err).ShouldNot(HaveOccurred())
+				push(ctx, queue, env1)
 
 				// Acquire a session for env0, but don't commit it.
 				sess, err := queue.Pop(ctx)
 				Expect(err).ShouldNot(HaveOccurred())
 				defer sess.Close()
 
-				// Nothing will new will be loaded from the store while there is
-				// anything at all in the buffer (this is why its important to
-				// configure the buffer size larger than the number of consumers).
+				// Nothing new will be loaded from the store while there is
+				// anything tracked at all (this is why its important to
+				// configure the buffer size larger than the number of
+				// consumers).
 				ctx, cancel := context.WithTimeout(ctx, 10*time.Millisecond)
 				defer cancel()
 
@@ -270,13 +273,13 @@ var _ = Describe("type Queue", func() {
 				Expect(err).To(Equal(context.DeadlineExceeded))
 			})
 
-			When("a message is pushed while loading from the store", func() {
+			When("a message is tracked while loading from the store", func() {
 				It("does not duplicate the message", func() {
 					repository.LoadQueueMessagesFunc = func(
 						ctx context.Context,
 						n int,
 					) ([]*queuestore.Message, error) {
-						queue.Push(ctx, env0)
+						push(ctx, queue, env0)
 						return repository.Repository.LoadQueueMessages(ctx, n)
 					}
 
@@ -300,6 +303,31 @@ var _ = Describe("type Queue", func() {
 	})
 
 	When("the queue is not running", func() {
+		Describe("func Track()", func() {
+			It("returns an error if the deadline is exceeded", func() {
+				m := &queuestore.Message{
+					Revision: 1,
+					Envelope: envelope.MustMarshal(Marshaler, env0),
+				}
+
+				// It's an implementation detail, but the internal channel used
+				// to start tracking is buffered at the same size as the overall
+				// buffer size limit.
+				queue.BufferSize = 1
+
+				// This track requuest should be pushed onto that buffered channel.
+				err := queue.Track(ctx, env0, m)
+				Expect(err).ShouldNot(HaveOccurred())
+
+				ctx, cancel := context.WithTimeout(ctx, 5*time.Millisecond)
+				defer cancel()
+
+				// But this one should block.
+				err = queue.Track(ctx, env0, m)
+				Expect(err).To(Equal(context.DeadlineExceeded))
+			})
+		})
+
 		Describe("fun Run()", func() {
 			It("returns an error if messages can not be loaded from the repository", func() {
 				repository.LoadQueueMessagesFunc = func(
@@ -316,5 +344,23 @@ var _ = Describe("type Queue", func() {
 	})
 
 	When("the queue has stopped", func() {
+		BeforeEach(func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel() // cancel immediately
+
+			queue.Run(ctx)
+		})
+
+		Describe("func Track()", func() {
+			It("does not block", func() {
+				m := &queuestore.Message{
+					Revision: 1,
+					Envelope: envelope.MustMarshal(Marshaler, env0),
+				}
+
+				err := queue.Track(ctx, env0, m)
+				Expect(err).ShouldNot(HaveOccurred())
+			})
+		})
 	})
 })

--- a/queue/queue_test.go
+++ b/queue/queue_test.go
@@ -95,14 +95,8 @@ var _ = Describe("type Queue", func() {
 	})
 
 	When("the queue is running", func() {
-		BeforeEach(func() {
-			q := queue
-
-			go func() {
-				defer GinkgoRecover()
-				err := q.Run(ctx)
-				Expect(err).To(Equal(context.Canceled))
-			}()
+		JustBeforeEach(func() {
+			go queue.Run(ctx)
 		})
 
 		Describe("func Pop()", func() {

--- a/queue/session_test.go
+++ b/queue/session_test.go
@@ -48,11 +48,14 @@ var _ = Describe("type Session", func() {
 			DataStore: dataStore,
 			Marshaler: Marshaler,
 		}
+	})
 
+	JustBeforeEach(func() {
 		go queue.Run(ctx)
 
 		push(ctx, queue, env0)
 
+		var err error
 		sess, err = queue.Pop(ctx)
 		Expect(err).ShouldNot(HaveOccurred())
 	})

--- a/queue/session_test.go
+++ b/queue/session_test.go
@@ -51,8 +51,7 @@ var _ = Describe("type Session", func() {
 
 		go queue.Run(ctx)
 
-		err = queue.Push(ctx, env0)
-		Expect(err).ShouldNot(HaveOccurred())
+		push(ctx, queue, env0)
 
 		sess, err = queue.Pop(ctx)
 		Expect(err).ShouldNot(HaveOccurred())
@@ -85,12 +84,11 @@ var _ = Describe("type Session", func() {
 			// Push a new envelope, which will get discarded from memory due to
 			// the buffer size limit.
 			queue.BufferSize = 1
-			err := queue.Push(ctx, env1)
-			Expect(err).ShouldNot(HaveOccurred())
+			push(ctx, queue, env1)
 
 			// Commit and close the existing session for env0, freeing us to
 			// load again.
-			err = sess.Commit(ctx)
+			err := sess.Commit(ctx)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			err = sess.Close()


### PR DESCRIPTION
We need to be able to track messages in the `queue.Queue` that are persisted as part of a transaction that was created while handling an event from a stream (that is, not a message from the queue).

This PR also fixes #113 (see dadac05).