### PR TITLE
Implement an adaptor to use a pipeline with an event stream.

### DIFF
--- a/eventstream.go
+++ b/eventstream.go
@@ -83,7 +83,6 @@ func (e *Engine) runStreamConsumerForProjection(
 			DefaultTimeout: e.opts.MessageTimeout,
 			Logger:         logger,
 		},
-		Semaphore:       e.semaphore,
 		BackoffStrategy: e.opts.MessageBackoff,
 		Logger:          logger,
 	}

--- a/eventstream/consumer_test.go
+++ b/eventstream/consumer_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/dogmatiq/infix/eventstream"
 	. "github.com/dogmatiq/infix/eventstream"
 	. "github.com/dogmatiq/infix/fixtures"
-	"github.com/dogmatiq/infix/handler"
 	"github.com/dogmatiq/linger/backoff"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -213,22 +212,6 @@ var _ = Describe("type Consumer", func() {
 			}()
 
 			err := consumer.Run(ctx)
-			Expect(err).To(Equal(context.Canceled))
-		})
-
-		It("returns if the context is canceled while waiting for the sempahore", func() {
-			consumer.Semaphore = handler.NewSemaphore(1)
-
-			err := consumer.Semaphore.Acquire(ctx)
-			Expect(err).ShouldNot(HaveOccurred())
-			defer consumer.Semaphore.Release()
-
-			go func() {
-				time.Sleep(100 * time.Millisecond)
-				cancel()
-			}()
-
-			err = consumer.Run(ctx)
 			Expect(err).To(Equal(context.Canceled))
 		})
 


### PR DESCRIPTION
This PR implements feature that expose event streams as a `pipeline.Source`.

It also removes `eventstream.Consumer.Semaphore`. This means projections, which do not produce NEW messages, and don't use the pipeline, are not subject to the message handling limit.