### PR TITLE
Improve error messages from envelope packer.

### DIFF
--- a/app.go
+++ b/app.go
@@ -143,11 +143,6 @@ func (e *Engine) newPipeline(
 ) pipeline.Port {
 	rf := &routeFactory{
 		opts: e.opts,
-		packer: &envelope.Packer{
-			Application: cfg.Identity(),
-			Produced:    cfg.MessageTypes().Produced,
-			Consumed:    cfg.MessageTypes().Consumed,
-		},
 	}
 
 	cfg.AcceptRichVisitor(nil, rf)
@@ -166,12 +161,13 @@ func (e *Engine) newPipeline(
 // routeFactory is a configkit.RichVisitor that constructs the messaging
 // pipeline.
 type routeFactory struct {
-	packer *envelope.Packer
+	app    configkit.Identity
 	opts   *engineOptions
 	routes map[message.Type]pipeline.Stage
 }
 
 func (f *routeFactory) VisitRichApplication(ctx context.Context, cfg configkit.RichApplication) error {
+	f.app = cfg.Identity()
 	f.routes = map[message.Type]pipeline.Stage{}
 	return cfg.RichHandlers().AcceptRichVisitor(ctx, f)
 }
@@ -188,8 +184,12 @@ func (f *routeFactory) VisitRichIntegration(_ context.Context, cfg configkit.Ric
 	s := &integration.Sink{
 		Identity:       cfg.Identity(),
 		Handler:        cfg.Handler(),
-		Packer:         f.packer,
 		DefaultTimeout: f.opts.MessageTimeout,
+		Packer: &envelope.Packer{
+			Application: f.app,
+			Produced:    cfg.MessageTypes().Produced,
+			Consumed:    cfg.MessageTypes().Consumed,
+		},
 	}
 
 	for mt := range cfg.MessageTypes().Consumed {

--- a/app.go
+++ b/app.go
@@ -73,7 +73,7 @@ func (e *Engine) initApp(
 
 	e.apps[id.Key] = a
 
-	for mt := range x.Packer.Roles {
+	for mt := range x.Packer.Produced {
 		e.executors[mt] = x
 	}
 
@@ -127,7 +127,7 @@ func (e *Engine) newCommandExecutor(
 		Queue: q,
 		Packer: &envelope.Packer{
 			Application: cfg.Identity(),
-			Roles: cfg.
+			Produced: cfg.
 				MessageTypes().
 				Consumed.
 				FilterByRole(message.CommandRole),
@@ -145,7 +145,8 @@ func (e *Engine) newPipeline(
 		opts: e.opts,
 		packer: &envelope.Packer{
 			Application: cfg.Identity(),
-			Roles:       cfg.MessageTypes().All(),
+			Produced:    cfg.MessageTypes().Produced,
+			Consumed:    cfg.MessageTypes().Consumed,
 		},
 	}
 

--- a/envelope/packer.go
+++ b/envelope/packer.go
@@ -1,6 +1,7 @@
 package envelope
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/dogmatiq/configkit"
@@ -29,32 +30,14 @@ type Packer struct {
 
 // PackCommand returns a new command envelope containing the given message.
 func (p *Packer) PackCommand(m dogma.Message) *Envelope {
-	id := p.generateID()
-
-	return p.new(
-		id,
-		id,
-		id,
-		m,
-		message.CommandRole,
-		configkit.Identity{},
-		"",
-	)
+	p.checkRole(m, message.CommandRole)
+	return p.new(m)
 }
 
 // PackEvent returns a new event envelope containing the given message.
 func (p *Packer) PackEvent(m dogma.Message) *Envelope {
-	id := p.generateID()
-
-	return p.new(
-		id,
-		id,
-		id,
-		m,
-		message.EventRole,
-		configkit.Identity{},
-		"",
-	)
+	p.checkRole(m, message.EventRole)
+	return p.new(m)
 }
 
 // PackChildCommand returns a new command envelope containing the given message
@@ -65,17 +48,12 @@ func (p *Packer) PackChildCommand(
 	handler configkit.Identity,
 	instanceID string,
 ) *Envelope {
-	mt := message.TypeOf(cause.Message)
-	p.Roles[mt].MustBe(message.EventRole, message.TimeoutRole)
+	p.checkRole(cause.Message, message.EventRole, message.TimeoutRole)
+	p.checkRole(m, message.CommandRole)
 
-	id := p.generateID()
-
-	return p.new(
-		id,
-		cause.MessageID,
-		cause.CorrelationID,
+	return p.newChild(
+		cause,
 		m,
-		message.CommandRole,
 		handler,
 		instanceID,
 	)
@@ -89,17 +67,12 @@ func (p *Packer) PackChildEvent(
 	handler configkit.Identity,
 	instanceID string,
 ) *Envelope {
-	mt := message.TypeOf(cause.Message)
-	p.Roles[mt].MustBe(message.CommandRole)
+	p.checkRole(cause.Message, message.CommandRole)
+	p.checkRole(m, message.EventRole)
 
-	id := p.generateID()
-
-	return p.new(
-		id,
-		cause.MessageID,
-		cause.CorrelationID,
+	return p.newChild(
+		cause,
 		m,
-		message.EventRole,
 		handler,
 		instanceID,
 	)
@@ -114,17 +87,12 @@ func (p *Packer) PackChildTimeout(
 	handler configkit.Identity,
 	instanceID string,
 ) *Envelope {
-	mt := message.TypeOf(cause.Message)
-	p.Roles[mt].MustBe(message.EventRole, message.TimeoutRole)
+	p.checkRole(cause.Message, message.EventRole, message.TimeoutRole)
+	p.checkRole(m, message.TimeoutRole)
 
-	id := p.generateID()
-
-	env := p.new(
-		id,
-		cause.MessageID,
-		cause.CorrelationID,
+	env := p.newChild(
+		cause,
 		m,
-		message.TimeoutRole,
 		handler,
 		instanceID,
 	)
@@ -134,35 +102,41 @@ func (p *Packer) PackChildTimeout(
 	return env
 }
 
-// new returns a new envelope, it panics if the given message type does not map
-// to the r role.
-func (p *Packer) new(
-	messageID string,
-	causationID string,
-	correlationID string,
-	m dogma.Message,
-	r message.Role,
-	handler configkit.Identity,
-	instanceID string,
-) *Envelope {
-	mt := message.TypeOf(m)
-	p.Roles[mt].MustBe(r)
+// new returns an envelope containing the given message.
+func (p *Packer) new(m dogma.Message) *Envelope {
+	id := p.generateID()
 
 	return &Envelope{
 		MetaData{
-			messageID,
-			causationID,
-			correlationID,
+			id,
+			id,
+			id,
 			Source{
-				p.Application,
-				handler,
-				instanceID,
+				Application: p.Application,
 			},
 			p.now(),
 			time.Time{},
 		},
 		m,
 	}
+}
+
+// newChild returns an envelope containing the given message, which was a
+// produced as a result of handling a causal message.
+func (p *Packer) newChild(
+	cause *Envelope,
+	m dogma.Message,
+	handler configkit.Identity,
+	instanceID string,
+) *Envelope {
+	env := p.new(m)
+
+	env.CausationID = cause.MessageID
+	env.CorrelationID = cause.CorrelationID
+	env.Source.Handler = handler
+	env.Source.InstanceID = instanceID
+
+	return env
 }
 
 // now returns the current time.
@@ -182,4 +156,16 @@ func (p *Packer) generateID() string {
 	}
 
 	return uuid.New().String()
+}
+
+// checkRolepatnics if mt does not fill one of the the given roles.
+func (p *Packer) checkRole(m dogma.Message, roles ...message.Role) {
+	mt := message.TypeOf(m)
+	x, ok := p.Roles[mt]
+
+	if !ok {
+		panic(fmt.Sprintf("%s is not a recognised message type", mt))
+	}
+
+	x.MustBe(roles...)
 }

--- a/envelope/packer_test.go
+++ b/envelope/packer_test.go
@@ -286,7 +286,11 @@ var _ = Describe("type Packer", func() {
 		})
 
 		It("panics if the message type is not recognized", func() {
-			Expect(func() {
+			fn := func() (v interface{}) {
+				defer func() {
+					v = recover()
+				}()
+
 				packer.PackChildTimeout(
 					parent,
 					MessageA1,
@@ -294,7 +298,11 @@ var _ = Describe("type Packer", func() {
 					configkit.MustNewIdentity("<handler-name>", "<handler-key>"),
 					"<instance>",
 				)
-			}).To(Panic())
+
+				return nil
+			}
+
+			Expect(fn()).To(Equal("fixtures.MessageA is not a recognised message type"))
 		})
 
 		It("panics if the message type has a different role", func() {

--- a/envelope/packer_test.go
+++ b/envelope/packer_test.go
@@ -7,10 +7,13 @@ import (
 	"github.com/dogmatiq/configkit"
 	. "github.com/dogmatiq/configkit/fixtures"
 	"github.com/dogmatiq/configkit/message"
+	"github.com/dogmatiq/dogma"
 	. "github.com/dogmatiq/dogma/fixtures"
 	. "github.com/dogmatiq/infix/envelope"
+	. "github.com/dogmatiq/infix/internal/x/gomegax"
 	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 )
 
@@ -26,10 +29,15 @@ var _ = Describe("type Packer", func() {
 		now = time.Now()
 		packer = &Packer{
 			Application: configkit.MustNewIdentity("<app-name>", "<app-key>"),
-			Roles: message.TypeRoles{
+			Produced: message.TypeRoles{
 				MessageCType: message.CommandRole,
 				MessageEType: message.EventRole,
 				MessageTType: message.TimeoutRole,
+			},
+			Consumed: message.TypeRoles{
+				MessageDType: message.CommandRole,
+				MessageFType: message.EventRole,
+				MessageUType: message.TimeoutRole,
 			},
 			GenerateID: func() string {
 				seq++
@@ -61,17 +69,17 @@ var _ = Describe("type Packer", func() {
 			))
 		})
 
-		It("panics if the message type is not recognized", func() {
-			Expect(func() {
-				packer.PackCommand(MessageA1)
-			}).To(Panic())
-		})
-
-		It("panics if the message type has a different role", func() {
-			Expect(func() {
-				packer.PackCommand(MessageE1)
-			}).To(Panic())
-		})
+		DescribeTable(
+			"it panics if the message type is incorrect",
+			func(m dogma.Message, x string) {
+				Expect(func() {
+					packer.PackCommand(m)
+				}).To(PanicWith(x))
+			},
+			Entry("when the message is unrecognized", MessageX1, "fixtures.MessageX is not a recognised message type"),
+			Entry("when the message is an event", MessageE1, "fixtures.MessageE is an event, expected a command"),
+			Entry("when the message is a timeout", MessageT1, "fixtures.MessageT is a timeout, expected a command"),
+		)
 	})
 
 	Describe("func PackEvent()", func() {
@@ -94,17 +102,17 @@ var _ = Describe("type Packer", func() {
 			))
 		})
 
-		It("panics if the message type is not recognized", func() {
-			Expect(func() {
-				packer.PackEvent(MessageA1)
-			}).To(Panic())
-		})
-
-		It("panics if the message type has a different role", func() {
-			Expect(func() {
-				packer.PackEvent(MessageC1)
-			}).To(Panic())
-		})
+		DescribeTable(
+			"it panics if the message type is incorrect",
+			func(m dogma.Message, x string) {
+				Expect(func() {
+					packer.PackEvent(m)
+				}).To(PanicWith(x))
+			},
+			Entry("when the message is unrecognized", MessageX1, "fixtures.MessageX is not a recognised message type"),
+			Entry("when the message is a command", MessageC1, "fixtures.MessageC is a command, expected an event"),
+			Entry("when the message is a timeout", MessageT1, "fixtures.MessageT is a timeout, expected an event"),
+		)
 	})
 
 	Describe("func PackChildCommand()", func() {
@@ -120,57 +128,78 @@ var _ = Describe("type Packer", func() {
 						Application: configkit.MustNewIdentity("<app-name>", "<app-key>"),
 					},
 				},
-				Message: MessageE1,
 			}
 		})
 
-		It("returns a new envelope", func() {
-			env := packer.PackChildCommand(
-				parent,
-				MessageC1,
-				configkit.MustNewIdentity("<handler-name>", "<handler-key>"),
-				"<instance>",
-			)
+		DescribeTable(
+			"it returns a new envelope",
+			func(p dogma.Message) {
+				parent.Message = p
 
-			Expect(env).To(Equal(
-				&Envelope{
-					MetaData: MetaData{
-						MessageID:     "00000001",
-						CausationID:   "<parent>",
-						CorrelationID: "<parent>",
-						Source: Source{
-							Application: configkit.MustNewIdentity("<app-name>", "<app-key>"),
-							Handler:     configkit.MustNewIdentity("<handler-name>", "<handler-key>"),
-							InstanceID:  "<instance>",
+				env := packer.PackChildCommand(
+					parent,
+					MessageC1,
+					configkit.MustNewIdentity("<handler-name>", "<handler-key>"),
+					"<instance>",
+				)
+
+				Expect(env).To(Equal(
+					&Envelope{
+						MetaData: MetaData{
+							MessageID:     "00000001",
+							CausationID:   "<parent>",
+							CorrelationID: "<parent>",
+							Source: Source{
+								Application: configkit.MustNewIdentity("<app-name>", "<app-key>"),
+								Handler:     configkit.MustNewIdentity("<handler-name>", "<handler-key>"),
+								InstanceID:  "<instance>",
+							},
+							CreatedAt: now,
 						},
-						CreatedAt: now,
+						Message: MessageC1,
 					},
-					Message: MessageC1,
-				},
-			))
-		})
+				))
+			},
+			Entry("when the parent is an event", MessageF1),
+			Entry("when the parent is a timeout", MessageU1),
+		)
 
-		It("panics if the message type is not recognized", func() {
-			Expect(func() {
-				packer.PackChildCommand(
-					parent,
-					MessageA1,
-					configkit.MustNewIdentity("<handler-name>", "<handler-key>"),
-					"<instance>",
-				)
-			}).To(Panic())
-		})
+		DescribeTable(
+			"it panics if the parent message type is incorrect",
+			func(p dogma.Message, x string) {
+				parent.Message = p
 
-		It("panics if the message type has a different role", func() {
-			Expect(func() {
-				packer.PackChildCommand(
-					parent,
-					MessageE1,
-					configkit.MustNewIdentity("<handler-name>", "<handler-key>"),
-					"<instance>",
-				)
-			}).To(Panic())
-		})
+				Expect(func() {
+					packer.PackChildCommand(
+						parent,
+						MessageC1,
+						configkit.MustNewIdentity("<handler-name>", "<handler-key>"),
+						"<instance>",
+					)
+				}).To(PanicWith(x))
+			},
+			Entry("when the message is unrecognized", MessageX1, "fixtures.MessageX is not consumed by this handler"),
+			Entry("when the message is a command", MessageD1, "fixtures.MessageD is a command, expected an event or timeout"),
+		)
+
+		DescribeTable(
+			"it panics if the message type is incorrect",
+			func(m dogma.Message, x string) {
+				parent.Message = MessageF1
+
+				Expect(func() {
+					packer.PackChildCommand(
+						parent,
+						m,
+						configkit.MustNewIdentity("<handler-name>", "<handler-key>"),
+						"<instance>",
+					)
+				}).To(PanicWith(x))
+			},
+			Entry("when the message is unrecognized", MessageX1, "fixtures.MessageX is not a recognised message type"),
+			Entry("when the message is an event", MessageE1, "fixtures.MessageE is an event, expected a command"),
+			Entry("when the message is a timeout", MessageT1, "fixtures.MessageT is a timeout, expected a command"),
+		)
 	})
 
 	Describe("func PackChildEvent()", func() {
@@ -186,57 +215,78 @@ var _ = Describe("type Packer", func() {
 						Application: configkit.MustNewIdentity("<app-name>", "<app-key>"),
 					},
 				},
-				Message: MessageC1,
 			}
 		})
 
-		It("returns a new envelope", func() {
-			env := packer.PackChildEvent(
-				parent,
-				MessageE1,
-				configkit.MustNewIdentity("<handler-name>", "<handler-key>"),
-				"<instance>",
-			)
+		DescribeTable(
+			"it returns a new envelope",
+			func(p dogma.Message) {
+				parent.Message = p
 
-			Expect(env).To(Equal(
-				&Envelope{
-					MetaData: MetaData{
-						MessageID:     "00000001",
-						CausationID:   "<parent>",
-						CorrelationID: "<parent>",
-						Source: Source{
-							Application: configkit.MustNewIdentity("<app-name>", "<app-key>"),
-							Handler:     configkit.MustNewIdentity("<handler-name>", "<handler-key>"),
-							InstanceID:  "<instance>",
+				env := packer.PackChildEvent(
+					parent,
+					MessageE1,
+					configkit.MustNewIdentity("<handler-name>", "<handler-key>"),
+					"<instance>",
+				)
+
+				Expect(env).To(Equal(
+					&Envelope{
+						MetaData: MetaData{
+							MessageID:     "00000001",
+							CausationID:   "<parent>",
+							CorrelationID: "<parent>",
+							Source: Source{
+								Application: configkit.MustNewIdentity("<app-name>", "<app-key>"),
+								Handler:     configkit.MustNewIdentity("<handler-name>", "<handler-key>"),
+								InstanceID:  "<instance>",
+							},
+							CreatedAt: now,
 						},
-						CreatedAt: now,
+						Message: MessageE1,
 					},
-					Message: MessageE1,
-				},
-			))
-		})
+				))
+			},
+			Entry("when the parent is a command", MessageD1),
+		)
 
-		It("panics if the message type is not recognized", func() {
-			Expect(func() {
-				packer.PackChildEvent(
-					parent,
-					MessageA1,
-					configkit.MustNewIdentity("<handler-name>", "<handler-key>"),
-					"<instance>",
-				)
-			}).To(Panic())
-		})
+		DescribeTable(
+			"it panics if the parent message type is incorrect",
+			func(p dogma.Message, x string) {
+				parent.Message = p
 
-		It("panics if the message type has a different role", func() {
-			Expect(func() {
-				packer.PackChildEvent(
-					parent,
-					MessageC1,
-					configkit.MustNewIdentity("<handler-name>", "<handler-key>"),
-					"<instance>",
-				)
-			}).To(Panic())
-		})
+				Expect(func() {
+					packer.PackChildEvent(
+						parent,
+						MessageE1,
+						configkit.MustNewIdentity("<handler-name>", "<handler-key>"),
+						"<instance>",
+					)
+				}).To(PanicWith(x))
+			},
+			Entry("when the message is unrecognized", MessageX1, "fixtures.MessageX is not consumed by this handler"),
+			Entry("when the message is an event", MessageF1, "fixtures.MessageF is an event, expected a command"),
+			Entry("when the message is a timeout", MessageU1, "fixtures.MessageU is a timeout, expected a command"),
+		)
+
+		DescribeTable(
+			"it panics if the message type is incorrect",
+			func(m dogma.Message, x string) {
+				parent.Message = MessageD1
+
+				Expect(func() {
+					packer.PackChildEvent(
+						parent,
+						m,
+						configkit.MustNewIdentity("<handler-name>", "<handler-key>"),
+						"<instance>",
+					)
+				}).To(PanicWith(x))
+			},
+			Entry("when the message is unrecognized", MessageX1, "fixtures.MessageX is not a recognised message type"),
+			Entry("when the message is a command", MessageC1, "fixtures.MessageC is a command, expected an event"),
+			Entry("when the message is a timeout", MessageT1, "fixtures.MessageT is a timeout, expected an event"),
+		)
 	})
 
 	Describe("func PackChildTimeout()", func() {
@@ -252,70 +302,83 @@ var _ = Describe("type Packer", func() {
 						Application: configkit.MustNewIdentity("<app-name>", "<app-key>"),
 					},
 				},
-				Message: MessageE1,
 			}
 		})
 
-		It("returns a new envelope", func() {
-			scheduledFor := time.Now()
-			env := packer.PackChildTimeout(
-				parent,
-				MessageT1,
-				scheduledFor,
-				configkit.MustNewIdentity("<handler-name>", "<handler-key>"),
-				"<instance>",
-			)
+		DescribeTable(
+			"it returns a new envelope",
+			func(p dogma.Message) {
+				parent.Message = p
 
-			Expect(env).To(Equal(
-				&Envelope{
-					MetaData: MetaData{
-						MessageID:     "00000001",
-						CausationID:   "<parent>",
-						CorrelationID: "<parent>",
-						Source: Source{
-							Application: configkit.MustNewIdentity("<app-name>", "<app-key>"),
-							Handler:     configkit.MustNewIdentity("<handler-name>", "<handler-key>"),
-							InstanceID:  "<instance>",
+				scheduledFor := time.Now()
+				env := packer.PackChildTimeout(
+					parent,
+					MessageT1,
+					scheduledFor,
+					configkit.MustNewIdentity("<handler-name>", "<handler-key>"),
+					"<instance>",
+				)
+
+				Expect(env).To(Equal(
+					&Envelope{
+						MetaData: MetaData{
+							MessageID:     "00000001",
+							CausationID:   "<parent>",
+							CorrelationID: "<parent>",
+							Source: Source{
+								Application: configkit.MustNewIdentity("<app-name>", "<app-key>"),
+								Handler:     configkit.MustNewIdentity("<handler-name>", "<handler-key>"),
+								InstanceID:  "<instance>",
+							},
+							CreatedAt:    now,
+							ScheduledFor: scheduledFor,
 						},
-						CreatedAt:    now,
-						ScheduledFor: scheduledFor,
+						Message: MessageT1,
 					},
-					Message: MessageT1,
-				},
-			))
-		})
+				))
+			},
+			Entry("when the parent is an event", MessageF1),
+			Entry("when the parent is a timeout", MessageU1),
+		)
 
-		It("panics if the message type is not recognized", func() {
-			fn := func() (v interface{}) {
-				defer func() {
-					v = recover()
-				}()
+		DescribeTable(
+			"it panics if the parent message type is incorrect",
+			func(p dogma.Message, x string) {
+				parent.Message = p
 
-				packer.PackChildTimeout(
-					parent,
-					MessageA1,
-					time.Now(),
-					configkit.MustNewIdentity("<handler-name>", "<handler-key>"),
-					"<instance>",
-				)
+				Expect(func() {
+					packer.PackChildTimeout(
+						parent,
+						MessageT1,
+						time.Now(),
+						configkit.MustNewIdentity("<handler-name>", "<handler-key>"),
+						"<instance>",
+					)
+				}).To(PanicWith(x))
+			},
+			Entry("when the message is unrecognized", MessageX1, "fixtures.MessageX is not consumed by this handler"),
+			Entry("when the message is a command", MessageD1, "fixtures.MessageD is a command, expected an event or timeout"),
+		)
 
-				return nil
-			}
+		DescribeTable(
+			"it panics if the message type is incorrect",
+			func(m dogma.Message, x string) {
+				parent.Message = MessageF1
 
-			Expect(fn()).To(Equal("fixtures.MessageA is not a recognised message type"))
-		})
-
-		It("panics if the message type has a different role", func() {
-			Expect(func() {
-				packer.PackChildTimeout(
-					parent,
-					MessageE1,
-					time.Now(),
-					configkit.MustNewIdentity("<handler-name>", "<handler-key>"),
-					"<instance>",
-				)
-			}).To(Panic())
-		})
+				Expect(func() {
+					packer.PackChildTimeout(
+						parent,
+						m,
+						time.Now(),
+						configkit.MustNewIdentity("<handler-name>", "<handler-key>"),
+						"<instance>",
+					)
+				}).To(PanicWith(x))
+			},
+			Entry("when the message is unrecognized", MessageX1, "fixtures.MessageX is not a recognised message type"),
+			Entry("when the message is a command", MessageC1, "fixtures.MessageC is a command, expected a timeout"),
+			Entry("when the message is an event", MessageE1, "fixtures.MessageE is an event, expected a timeout"),
+		)
 	})
 
 	It("generates UUIDs by default", func() {

--- a/fixtures/envelope.go
+++ b/fixtures/envelope.go
@@ -101,6 +101,8 @@ func cleanseTime(t *time.Time) {
 //
 // MessageID is a monotonically increasing integer, starting at 0. CreatedAt
 // starts at 2000-01-01 00:00:00 UTC and increases by 1 second for each message.
+//
+// The given roles are valid both as produced and consumed roles.
 func NewPacker(roles message.TypeRoles) *envelope.Packer {
 	var (
 		m   sync.Mutex
@@ -110,7 +112,8 @@ func NewPacker(roles message.TypeRoles) *envelope.Packer {
 
 	return &envelope.Packer{
 		Application: configkit.MustNewIdentity("<app-name>", "<app-key>"),
-		Roles:       roles,
+		Produced:    roles,
+		Consumed:    roles,
 		GenerateID: func() string {
 			m.Lock()
 			defer m.Unlock()

--- a/internal/x/gomegax/panicwith.go
+++ b/internal/x/gomegax/panicwith.go
@@ -1,0 +1,73 @@
+package gomegax
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/onsi/gomega"
+	"github.com/onsi/gomega/format"
+	"github.com/onsi/gomega/types"
+)
+
+// PanicWith is a matcher that expects a specific panic value.
+func PanicWith(v interface{}) types.GomegaMatcher {
+	m, ok := v.(types.GomegaMatcher)
+	if !ok {
+		m = gomega.Equal(v)
+	}
+
+	return &panicWithMatcher{Matcher: m}
+}
+
+type panicWithMatcher struct {
+	Matcher  types.GomegaMatcher
+	panicked bool
+	matched  bool
+	object   interface{}
+}
+
+func (m *panicWithMatcher) Match(actual interface{}) (bool, error) {
+	if actual == nil {
+		return false, fmt.Errorf("PanicWith expects a non-nil actual")
+	}
+
+	actualType := reflect.TypeOf(actual)
+	if actualType.Kind() != reflect.Func {
+		return false, fmt.Errorf("PanicWith expects a function.  Got:\n%s", format.Object(actual, 1))
+	}
+	if !(actualType.NumIn() == 0 && actualType.NumOut() == 0) {
+		return false, fmt.Errorf("PanicWith expects a function with no arguments and no return value.  Got:\n%s", format.Object(actual, 1))
+	}
+
+	func() {
+		defer func() {
+			if e := recover(); e != nil {
+				m.object = e
+				m.panicked = true
+			}
+		}()
+
+		reflect.ValueOf(actual).Call([]reflect.Value{})
+	}()
+
+	if !m.panicked {
+		return false, nil
+	}
+
+	var err error
+	m.matched, err = m.Matcher.Match(m.object)
+
+	return m.matched, err
+}
+
+func (m *panicWithMatcher) FailureMessage(actual interface{}) (message string) {
+	if m.panicked {
+		return m.Matcher.FailureMessage(m.object)
+	}
+
+	return format.Message(actual, "to panic")
+}
+
+func (m *panicWithMatcher) NegatedFailureMessage(actual interface{}) (message string) {
+	return m.Matcher.NegatedFailureMessage(m.object)
+}


### PR DESCRIPTION
Fixes #137 

I've gone to some length to ensure the panic messages here are fairly straightforward, as users will see these panics if they execute/record the wrong messages via the various scope interfaces.