### PR TITLE
Log produced messages.

### DIFF
--- a/handler/integration/scope.go
+++ b/handler/integration/scope.go
@@ -1,8 +1,6 @@
 package integration
 
 import (
-	"fmt"
-
 	"github.com/dogmatiq/configkit"
 	"github.com/dogmatiq/dodeca/logging"
 	"github.com/dogmatiq/dogma"
@@ -22,34 +20,20 @@ type scope struct {
 // RecordEvent records the occurrence of an event as a result of the command
 // message that is being handled.
 func (s *scope) RecordEvent(m dogma.Message) {
-	s.events = append(
-		s.events,
-		s.packer.PackChildEvent(
-			s.cause,
-			m,
-			s.handler,
-			"",
-		),
+	env := s.packer.PackChildEvent(
+		s.cause,
+		m,
+		s.handler,
+		"",
 	)
+
+	mlog.LogProduce(s.logger, env)
+
+	s.events = append(s.events, env)
 }
 
 // Log records an informational message within the context of the message
 // that is being handled.
 func (s *scope) Log(f string, v ...interface{}) {
-	logging.Log(
-		s.logger,
-		mlog.String(
-			[]mlog.IconWithLabel{
-				mlog.MessageIDIcon.WithID(s.cause.MessageID),
-				mlog.CausationIDIcon.WithID(s.cause.CausationID),
-				mlog.CorrelationIDIcon.WithID(s.cause.CorrelationID),
-			},
-			[]mlog.Icon{
-				mlog.InboundIcon,
-				mlog.IntegrationIcon,
-			},
-			s.handler.Name,
-			fmt.Sprintf(f, v...),
-		),
-	)
+	mlog.LogFromHandler(s.logger, s.cause, f, v)
 }

--- a/handler/integration/sink_test.go
+++ b/handler/integration/sink_test.go
@@ -124,6 +124,27 @@ var _ = Describe("type Sink", func() {
 			Expect(scope.Recorded[0].Memory).To(Equal(effect))
 		})
 
+		It("logs about recorded events", func() {
+			handler.HandleCommandFunc = func(
+				_ context.Context,
+				s dogma.IntegrationCommandScope,
+				_ dogma.Message,
+			) error {
+				s.RecordEvent(MessageE1)
+				return nil
+			}
+
+			err := sink.Accept(context.Background(), scope)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			logger := scope.Logger.(*logging.BufferedLogger)
+			Expect(logger.Messages()).To(ContainElement(
+				logging.BufferedLogMessage{
+					Message: "= 0  ∵ <id>  ⋲ <correlation>  ▲    fixtures.MessageE ● {E1}",
+				},
+			))
+		})
+
 		It("returns an error if an event can not be recorded", func() {
 			tx.SaveEventFunc = func(
 				context.Context,
@@ -161,7 +182,7 @@ var _ = Describe("type Sink", func() {
 			logger := scope.Logger.(*logging.BufferedLogger)
 			Expect(logger.Messages()).To(ContainElement(
 				logging.BufferedLogMessage{
-					Message: "= <id>  ∵ <cause>  ⋲ <correlation>  ▼ ⨝  <integration-name> ● format <value>",
+					Message: "= <id>  ∵ <cause>  ⋲ <correlation>  ▼    fixtures.MessageC ● format <value>",
 				},
 			))
 		})

--- a/internal/mlog/icon.go
+++ b/internal/mlog/icon.go
@@ -26,32 +26,33 @@ const (
 	// happened "because of" the displayed ID.
 	CausationIDIcon Icon = "∵"
 
-	// CorrelationIDIcon is the icon shown directly before a message correlation ID.
-	// It is the mathematical "member of set" symbol, indicating that this message
-	// belongs to the set of messages that came about because of the displayed ID.
+	// CorrelationIDIcon is the icon shown directly before a message correlation
+	// ID. It is the mathematical "member of set" symbol, indicating that this
+	// message belongs to the set of messages that came about because of the
+	// displayed ID.
 	CorrelationIDIcon Icon = "⋲"
 
-	// InboundIcon is the icon shown to indicate that a message is "inbound" to a handler.
-	// It is a downward pointing arrow, as inbound messages could be considered as
-	// being "downloaded" from the network or queue.
-	InboundIcon Icon = "▼"
+	// ConsumeIcon is the icon shown to indicate that a message is being
+	// consumed. It is a downward pointing arrow, as such "inbound" messages
+	// could be considered as being "downloaded" from the network or queue.
+	ConsumeIcon Icon = "▼"
 
-	// InboundErrorIcon is a variant of InboundIcon used when there is an error
-	// condition. It is an hollow version of the regular inbound icon, indicating
-	// that the requirement remains "unfulfilled".
-	InboundErrorIcon Icon = "▽"
+	// ConsumeErrorIcon is a variant of ConsumeIcon used when there is an error
+	// condition. It is an hollow version of the regular consume icon,
+	// indicating that the requirement remains "unfulfilled".
+	ConsumeErrorIcon Icon = "▽"
 
-	// OutboundIcon is the icon shown to indicate that a message is "outbound" from
-	// a handler. It is an upward pointing arrow, as outbound messages could be
-	// considered as being "uploaded" to the network or queue.
-	OutboundIcon Icon = "▲"
+	// ProduceIcon is the icon shown to indicate that a message is being
+	// produce. It is an upward pointing arrow, as such "outbound" messages
+	// could be considered as being "uploaded" to the network or queue.
+	ProduceIcon Icon = "▲"
 
-	// OutboundErrorIcon is a variant of OutboundIcon used when there is an error
-	// condition. It is an hollow version of the regular inbound icon, indicating
-	// that the requirement remains "unfulfilled".
-	OutboundErrorIcon Icon = "△"
+	// ProduceErrorIcon is a variant of ProduceIcon used when there is an error
+	// condition. It is an hollow version of the regular produce icon,
+	// indicating that the requirement remains "unfulfilled".
+	ProduceErrorIcon Icon = "△"
 
-	// RetryIcon is an icon used instead of InboundIcon when a message is being
+	// RetryIcon is an icon used instead of ConsumeIcon when a message is being
 	// re-attempted. It is an open-circle with an arrow, indicating that the
 	// message has "come around again".
 	RetryIcon Icon = "↻"

--- a/internal/mlog/log_test.go
+++ b/internal/mlog/log_test.go
@@ -46,6 +46,23 @@ var _ = Describe("func LogConsume()", func() {
 	})
 })
 
+var _ = Describe("func LogProduce()", func() {
+	It("logs in the correct format", func() {
+		logger := &logging.BufferedLogger{}
+
+		LogProduce(
+			logger,
+			NewEnvelope("<id>", MessageA1),
+		)
+
+		Expect(logger.Messages()).To(ContainElement(
+			logging.BufferedLogMessage{
+				Message: "= <id>  ∵ <cause>  ⋲ <correlation>  ▲    fixtures.MessageA ● {A1}",
+			},
+		))
+	})
+})
+
 var _ = Describe("func LogNack()", func() {
 	It("logs in the correct format", func() {
 		logger := &logging.BufferedLogger{}

--- a/internal/mlog/log_test.go
+++ b/internal/mlog/log_test.go
@@ -12,11 +12,11 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("func LogSuccess()", func() {
+var _ = Describe("func LogConsume()", func() {
 	It("logs in the correct format", func() {
 		logger := &logging.BufferedLogger{}
 
-		LogSuccess(
+		LogConsume(
 			logger,
 			NewEnvelope("<id>", MessageA1),
 			0,
@@ -32,7 +32,7 @@ var _ = Describe("func LogSuccess()", func() {
 	It("shows a retry icon if the failure count is non-zero", func() {
 		logger := &logging.BufferedLogger{}
 
-		LogSuccess(
+		LogConsume(
 			logger,
 			NewEnvelope("<id>", MessageA1),
 			1,
@@ -46,11 +46,11 @@ var _ = Describe("func LogSuccess()", func() {
 	})
 })
 
-var _ = Describe("func LogFailure()", func() {
+var _ = Describe("func LogNack()", func() {
 	It("logs in the correct format", func() {
 		logger := &logging.BufferedLogger{}
 
-		LogFailure(
+		LogNack(
 			logger,
 			NewEnvelope("<id>", MessageA1),
 			errors.New("<error>"),
@@ -59,17 +59,17 @@ var _ = Describe("func LogFailure()", func() {
 
 		Expect(logger.Messages()).To(ContainElement(
 			logging.BufferedLogMessage{
-				Message: "= <id>  ∵ <cause>  ⋲ <correlation>  ▽ ✖  fixtures.MessageA ● <error> ● next retry in 5s ● {A1}",
+				Message: "= <id>  ∵ <cause>  ⋲ <correlation>  ▽ ✖  fixtures.MessageA ● <error> ● next retry in 5s",
 			},
 		))
 	})
 })
 
-var _ = Describe("func LogFailureWithoutEnvelope()", func() {
+var _ = Describe("func LogNackWithoutEnvelope()", func() {
 	It("logs in the correct format", func() {
 		logger := &logging.BufferedLogger{}
 
-		LogFailureWithoutEnvelope(
+		LogNackWithoutEnvelope(
 			logger,
 			"<id>",
 			errors.New("<error>"),
@@ -79,6 +79,25 @@ var _ = Describe("func LogFailureWithoutEnvelope()", func() {
 		Expect(logger.Messages()).To(ContainElement(
 			logging.BufferedLogMessage{
 				Message: "= <id>  ∵ -  ⋲ -  ▽ ✖  <error> ● next retry in 5s",
+			},
+		))
+	})
+})
+
+var _ = Describe("func LogFromHandler()", func() {
+	It("logs in the correct format", func() {
+		logger := &logging.BufferedLogger{}
+
+		LogFromHandler(
+			logger,
+			NewEnvelope("<id>", MessageA1),
+			"format %s",
+			[]interface{}{"<value>"},
+		)
+
+		Expect(logger.Messages()).To(ContainElement(
+			logging.BufferedLogMessage{
+				Message: "= <id>  ∵ <cause>  ⋲ <correlation>  ▼    fixtures.MessageA ● format <value>",
 			},
 		))
 	})

--- a/internal/mlog/write_test.go
+++ b/internal/mlog/write_test.go
@@ -18,7 +18,7 @@ var entries = []TableEntry{
 			CorrelationIDIcon.WithLabel("789"),
 		},
 		[]Icon{
-			InboundIcon,
+			ConsumeIcon,
 			RetryIcon,
 		},
 		[]string{
@@ -35,7 +35,7 @@ var entries = []TableEntry{
 			CorrelationIDIcon.WithLabel(""),
 		},
 		[]Icon{
-			InboundIcon,
+			ConsumeIcon,
 			"",
 		},
 		[]string{
@@ -52,7 +52,7 @@ var entries = []TableEntry{
 			CorrelationIDIcon.WithLabel("789"),
 		},
 		[]Icon{
-			InboundIcon,
+			ConsumeIcon,
 			"",
 		},
 		[]string{
@@ -70,7 +70,7 @@ var entries = []TableEntry{
 			CorrelationIDIcon.WithLabel("789"),
 		},
 		[]Icon{
-			InboundIcon,
+			ConsumeIcon,
 			RetryIcon,
 		},
 		[]string{

--- a/pipeline/ack.go
+++ b/pipeline/ack.go
@@ -29,11 +29,16 @@ func Acknowledge(bs backoff.Strategy) Stage {
 			return nack(ctx, bs, sc, nil, err)
 		}
 
+		mlog.LogConsume(
+			sc.Logger,
+			env,
+			sc.Session.FailureCount(),
+		)
+
 		if err := next(ctx, sc); err != nil {
 			return nack(ctx, bs, sc, env, err)
 		}
 
-		mlog.LogSuccess(sc.Logger, env, sc.Session.FailureCount())
 		return sc.Session.Ack(ctx)
 	}
 }
@@ -49,14 +54,14 @@ func nack(
 	delay := bs(cause, sc.Session.FailureCount())
 
 	if env == nil {
-		mlog.LogFailureWithoutEnvelope(
+		mlog.LogNackWithoutEnvelope(
 			sc.Logger,
 			sc.Session.MessageID(),
 			cause,
 			delay,
 		)
 	} else {
-		mlog.LogFailure(
+		mlog.LogNack(
 			sc.Logger,
 			env,
 			cause,

--- a/pipeline/ack_test.go
+++ b/pipeline/ack_test.go
@@ -49,7 +49,7 @@ var _ = Describe("func Acknowledge()", func() {
 			Expect(called).To(BeTrue())
 		})
 
-		It("logs about acknowledgement", func() {
+		It("logs about consuming", func() {
 			err := ack(context.Background(), scope, next)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(logger.Messages()).To(ContainElement(
@@ -85,12 +85,22 @@ var _ = Describe("func Acknowledge()", func() {
 			Expect(called).To(BeTrue())
 		})
 
+		It("logs about consuming", func() {
+			err := ack(context.Background(), scope, next)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(logger.Messages()).To(ContainElement(
+				logging.BufferedLogMessage{
+					Message: "= <id>  ∵ <cause>  ⋲ <correlation>  ▼    fixtures.MessageA ● {A1}",
+				},
+			))
+		})
+
 		It("logs about negative acknowledgement", func() {
 			err := ack(context.Background(), scope, next)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(logger.Messages()).To(ContainElement(
 				logging.BufferedLogMessage{
-					Message: "= <id>  ∵ <cause>  ⋲ <correlation>  ▽ ✖  fixtures.MessageA ● <failed> ● next retry in 1s ● {A1}",
+					Message: "= <id>  ∵ <cause>  ⋲ <correlation>  ▽ ✖  fixtures.MessageA ● <failed> ● next retry in 1s",
 				},
 			))
 		})


### PR DESCRIPTION
Fixes #131 

This PR adds logging of messages that are produced by integration handlers.

The logging occurs immediately, so if the transaction is latter rolled back you can still see that the handler recorded them, but you have to ensure there's no error latter in the log. 

I've also changed the `Acknowledger` to always log when a message comes in, not only when it's acknowledged. This puts the log messages in the correct order, with the "cause" showing before the "effect".

As best I can tell, this behavior is the same as Ax.