### PR TITLE
Add aggregatestore persistence subsystem.

### DIFF
--- a/fixtures/aggregatestore.go
+++ b/fixtures/aggregatestore.go
@@ -1,0 +1,28 @@
+package fixtures
+
+import (
+	"context"
+
+	"github.com/dogmatiq/infix/persistence/subsystem/aggregatestore"
+)
+
+// AggregateStoreRepositoryStub is a test implementation of the
+// aggregatestore.Repository interface.
+type AggregateStoreRepositoryStub struct {
+	aggregatestore.Repository
+
+	LoadRevisionFunc func(context.Context, string, string) (aggregatestore.Revision, error)
+}
+
+// LoadRevision loads the current revision of an aggregate instance.
+func (r *AggregateStoreRepositoryStub) LoadRevision(ctx context.Context, hk, id string) (aggregatestore.Revision, error) {
+	if r.LoadRevisionFunc != nil {
+		return r.LoadRevisionFunc(ctx, hk, id)
+	}
+
+	if r.Repository != nil {
+		return r.Repository.LoadRevision(ctx, hk, id)
+	}
+
+	return 0, nil
+}

--- a/fixtures/persistence.go
+++ b/fixtures/persistence.go
@@ -6,6 +6,7 @@ import (
 	"github.com/dogmatiq/infix/draftspecs/envelopespec"
 	"github.com/dogmatiq/infix/persistence"
 	"github.com/dogmatiq/infix/persistence/provider/memory"
+	"github.com/dogmatiq/infix/persistence/subsystem/aggregatestore"
 	"github.com/dogmatiq/infix/persistence/subsystem/eventstore"
 	"github.com/dogmatiq/infix/persistence/subsystem/queuestore"
 )
@@ -134,12 +135,27 @@ func (ds *DataStoreStub) Close() error {
 type TransactionStub struct {
 	persistence.Transaction
 
-	SaveEventFunc              func(context.Context, *envelopespec.Envelope) (eventstore.Offset, error)
-	SaveMessageToQueueFunc     func(context.Context, *queuestore.Item) error
-	RemoveMessageFromQueueFunc func(context.Context, *queuestore.Item) error
+	IncrementAggregateRevisionFunc func(context.Context, string, string, aggregatestore.Revision) error
+	SaveEventFunc                  func(context.Context, *envelopespec.Envelope) (eventstore.Offset, error)
+	SaveMessageToQueueFunc         func(context.Context, *queuestore.Item) error
+	RemoveMessageFromQueueFunc     func(context.Context, *queuestore.Item) error
 
 	CommitFunc   func(context.Context) error
 	RollbackFunc func() error
+}
+
+// IncrementAggregateRevision increments the persisted revision of a an
+// aggregate instance.
+func (t *TransactionStub) IncrementAggregateRevision(ctx context.Context, hk, id string, c aggregatestore.Revision) error {
+	if t.IncrementAggregateRevisionFunc != nil {
+		return t.IncrementAggregateRevisionFunc(ctx, hk, id, c)
+	}
+
+	if t.Transaction != nil {
+		return t.Transaction.IncrementAggregateRevision(ctx, hk, id, c)
+	}
+
+	return nil
 }
 
 // SaveEvent persists an event in the application's event store.

--- a/persistence/datastore.go
+++ b/persistence/datastore.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"sync"
 
+	"github.com/dogmatiq/infix/persistence/subsystem/aggregatestore"
 	"github.com/dogmatiq/infix/persistence/subsystem/eventstore"
 	"github.com/dogmatiq/infix/persistence/subsystem/queuestore"
 	"go.uber.org/multierr"
@@ -17,6 +18,9 @@ var ErrDataStoreClosed = errors.New("data store is closed")
 // DataStore is an interface used by the engine to persist and retrieve
 // data for a specific application.
 type DataStore interface {
+	// AggregateStoreRepository returns application's aggregate store repository.
+	AggregateStoreRepository() aggregatestore.Repository
+
 	// EventStoreRepository returns the application's event store repository.
 	EventStoreRepository() eventstore.Repository
 

--- a/persistence/internal/providertest/aggregatestore/repository.go
+++ b/persistence/internal/providertest/aggregatestore/repository.go
@@ -1,0 +1,60 @@
+package aggregatestore
+
+import (
+	"context"
+
+	"github.com/dogmatiq/infix/persistence"
+	"github.com/dogmatiq/infix/persistence/internal/providertest/common"
+	"github.com/dogmatiq/infix/persistence/subsystem/aggregatestore"
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
+)
+
+// DeclareRepositoryTests declares a functional test-suite for a specific
+// aggregatestore.Repository implementation.
+func DeclareRepositoryTests(tc *common.TestContext) {
+	ginkgo.XDescribe("type aggregatestore.Repository", func() {
+		var (
+			dataStore  persistence.DataStore
+			repository aggregatestore.Repository
+			tearDown   func()
+		)
+
+		ginkgo.BeforeEach(func() {
+			dataStore, tearDown = tc.SetupDataStore()
+			repository = dataStore.AggregateStoreRepository()
+		})
+
+		ginkgo.AfterEach(func() {
+			tearDown()
+		})
+
+		ginkgo.Describe("func LoadRevision()", func() {
+			ginkgo.It("returns zero if the instance does not exist", func() {
+				rev := loadRevision(tc.Context, repository, "<handler-key>", "<instance>")
+				gomega.Expect(rev).To(gomega.BeEquivalentTo(0))
+			})
+
+			ginkgo.It("returns the current revision", func() {
+				incrementRevision(
+					tc.Context,
+					dataStore,
+					"<handler-key>",
+					"<instance>",
+					0,
+				)
+
+				rev := loadRevision(tc.Context, repository, "<handler-key>", "<instance>")
+				gomega.Expect(rev).To(gomega.BeEquivalentTo(1))
+			})
+
+			ginkgo.It("returns an error if the context is canceled", func() {
+				ctx, cancel := context.WithCancel(tc.Context)
+				cancel()
+
+				_, err := repository.LoadRevision(ctx, "<handler-key>", "<instance>")
+				gomega.Expect(err).To(gomega.Equal(context.Canceled))
+			})
+		})
+	})
+}

--- a/persistence/internal/providertest/aggregatestore/repository.go
+++ b/persistence/internal/providertest/aggregatestore/repository.go
@@ -48,7 +48,7 @@ func DeclareRepositoryTests(tc *common.TestContext) {
 				gomega.Expect(rev).To(gomega.BeEquivalentTo(1))
 			})
 
-			ginkgo.XIt("returns an error if the context is canceled", func() {
+			ginkgo.It("returns an error if the context is canceled", func() {
 				ctx, cancel := context.WithCancel(tc.Context)
 				cancel()
 

--- a/persistence/internal/providertest/aggregatestore/repository.go
+++ b/persistence/internal/providertest/aggregatestore/repository.go
@@ -35,7 +35,7 @@ func DeclareRepositoryTests(tc *common.TestContext) {
 				gomega.Expect(rev).To(gomega.BeEquivalentTo(0))
 			})
 
-			ginkgo.XIt("returns the current revision", func() {
+			ginkgo.It("returns the current revision", func() {
 				incrementRevision(
 					tc.Context,
 					dataStore,

--- a/persistence/internal/providertest/aggregatestore/repository.go
+++ b/persistence/internal/providertest/aggregatestore/repository.go
@@ -13,7 +13,7 @@ import (
 // DeclareRepositoryTests declares a functional test-suite for a specific
 // aggregatestore.Repository implementation.
 func DeclareRepositoryTests(tc *common.TestContext) {
-	ginkgo.XDescribe("type aggregatestore.Repository", func() {
+	ginkgo.Describe("type aggregatestore.Repository", func() {
 		var (
 			dataStore  persistence.DataStore
 			repository aggregatestore.Repository
@@ -35,7 +35,7 @@ func DeclareRepositoryTests(tc *common.TestContext) {
 				gomega.Expect(rev).To(gomega.BeEquivalentTo(0))
 			})
 
-			ginkgo.It("returns the current revision", func() {
+			ginkgo.XIt("returns the current revision", func() {
 				incrementRevision(
 					tc.Context,
 					dataStore,
@@ -48,7 +48,7 @@ func DeclareRepositoryTests(tc *common.TestContext) {
 				gomega.Expect(rev).To(gomega.BeEquivalentTo(1))
 			})
 
-			ginkgo.It("returns an error if the context is canceled", func() {
+			ginkgo.XIt("returns an error if the context is canceled", func() {
 				ctx, cancel := context.WithCancel(tc.Context)
 				cancel()
 

--- a/persistence/internal/providertest/aggregatestore/transaction.go
+++ b/persistence/internal/providertest/aggregatestore/transaction.go
@@ -98,7 +98,7 @@ func DeclareTransactionTests(tc *common.TestContext) {
 					)
 				})
 
-				ginkgo.XIt("increments the revision", func() {
+				ginkgo.It("increments the revision", func() {
 					incrementRevision(
 						tc.Context,
 						dataStore,

--- a/persistence/internal/providertest/aggregatestore/transaction.go
+++ b/persistence/internal/providertest/aggregatestore/transaction.go
@@ -15,7 +15,7 @@ import (
 // DeclareTransactionTests declares a functional test-suite for a specific
 // aggregatestore.Transaction implementation.
 func DeclareTransactionTests(tc *common.TestContext) {
-	ginkgo.XDescribe("type aggregatestore.Transaction", func() {
+	ginkgo.Describe("type aggregatestore.Transaction", func() {
 		var (
 			dataStore  persistence.DataStore
 			repository aggregatestore.Repository
@@ -33,7 +33,7 @@ func DeclareTransactionTests(tc *common.TestContext) {
 
 		ginkgo.Describe("func IncrementAggregateRevision()", func() {
 			ginkgo.When("the instance does not exist", func() {
-				ginkgo.It("sets the revision to 1", func() {
+				ginkgo.XIt("sets the revision to 1", func() {
 					incrementRevision(
 						tc.Context,
 						dataStore,
@@ -46,7 +46,7 @@ func DeclareTransactionTests(tc *common.TestContext) {
 					gomega.Expect(rev).To(gomega.BeEquivalentTo(1))
 				})
 
-				ginkgo.It("does not increment the revision if the transaction is rolled back", func() {
+				ginkgo.XIt("does not increment the revision if the transaction is rolled back", func() {
 					err := common.WithTransactionRollback(
 						tc.Context,
 						dataStore,
@@ -65,7 +65,7 @@ func DeclareTransactionTests(tc *common.TestContext) {
 					gomega.Expect(rev).To(gomega.BeEquivalentTo(0))
 				})
 
-				ginkgo.It("does not save the message when an OCC conflict occurs", func() {
+				ginkgo.XIt("does not save the message when an OCC conflict occurs", func() {
 					err := persistence.WithTransaction(
 						tc.Context,
 						dataStore,
@@ -98,7 +98,7 @@ func DeclareTransactionTests(tc *common.TestContext) {
 					)
 				})
 
-				ginkgo.It("increments the revision", func() {
+				ginkgo.XIt("increments the revision", func() {
 					incrementRevision(
 						tc.Context,
 						dataStore,
@@ -111,7 +111,7 @@ func DeclareTransactionTests(tc *common.TestContext) {
 					gomega.Expect(rev).To(gomega.BeEquivalentTo(2))
 				})
 
-				ginkgo.It("does not update the message if the transaction is rolled-back", func() {
+				ginkgo.XIt("does not update the message if the transaction is rolled-back", func() {
 					err := common.WithTransactionRollback(
 						tc.Context,
 						dataStore,
@@ -171,7 +171,7 @@ func DeclareTransactionTests(tc *common.TestContext) {
 			})
 
 			ginkgo.When("an instance's revision is incremented more than once in the same transaction", func() {
-				ginkgo.It("saves the highest revision", func() {
+				ginkgo.XIt("saves the highest revision", func() {
 					err := persistence.WithTransaction(
 						tc.Context,
 						dataStore,
@@ -199,7 +199,7 @@ func DeclareTransactionTests(tc *common.TestContext) {
 					gomega.Expect(rev).To(gomega.BeEquivalentTo(2))
 				})
 
-				ginkgo.It("uses the uncommitted revision for OCC checks", func() {
+				ginkgo.XIt("uses the uncommitted revision for OCC checks", func() {
 					err := common.WithTransactionRollback(
 						tc.Context,
 						dataStore,
@@ -226,7 +226,7 @@ func DeclareTransactionTests(tc *common.TestContext) {
 				})
 			})
 
-			ginkgo.It("serializes operations from competing transactions", func() {
+			ginkgo.XIt("serializes operations from competing transactions", func() {
 				ginkgo.By("running several transactions in parallel")
 
 				var g sync.WaitGroup

--- a/persistence/internal/providertest/aggregatestore/transaction.go
+++ b/persistence/internal/providertest/aggregatestore/transaction.go
@@ -1,0 +1,277 @@
+package aggregatestore
+
+import (
+	"sync"
+
+	"github.com/dogmatiq/infix/persistence"
+	"github.com/dogmatiq/infix/persistence/internal/providertest/common"
+	"github.com/dogmatiq/infix/persistence/subsystem/aggregatestore"
+	"github.com/dogmatiq/infix/persistence/subsystem/queuestore"
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/extensions/table"
+	"github.com/onsi/gomega"
+)
+
+// DeclareTransactionTests declares a functional test-suite for a specific
+// aggregatestore.Transaction implementation.
+func DeclareTransactionTests(tc *common.TestContext) {
+	ginkgo.XDescribe("type aggregatestore.Transaction", func() {
+		var (
+			dataStore  persistence.DataStore
+			repository aggregatestore.Repository
+			tearDown   func()
+		)
+
+		ginkgo.BeforeEach(func() {
+			dataStore, tearDown = tc.SetupDataStore()
+			repository = dataStore.AggregateStoreRepository()
+		})
+
+		ginkgo.AfterEach(func() {
+			tearDown()
+		})
+
+		ginkgo.Describe("func IncrementAggregateRevision()", func() {
+			ginkgo.When("the instance does not exist", func() {
+				ginkgo.It("sets the revision to 1", func() {
+					incrementRevision(
+						tc.Context,
+						dataStore,
+						"<handler-key>",
+						"<instance>",
+						0,
+					)
+
+					rev := loadRevision(tc.Context, repository, "<handler-key>", "<instance>")
+					gomega.Expect(rev).To(gomega.BeEquivalentTo(1))
+				})
+
+				ginkgo.It("does not increment the revision if the transaction is rolled back", func() {
+					err := common.WithTransactionRollback(
+						tc.Context,
+						dataStore,
+						func(tx persistence.ManagedTransaction) error {
+							return tx.IncrementAggregateRevision(
+								tc.Context,
+								"<handler-key>",
+								"<instance>",
+								0,
+							)
+						},
+					)
+					gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+
+					rev := loadRevision(tc.Context, repository, "<handler-key>", "<instance>")
+					gomega.Expect(rev).To(gomega.BeEquivalentTo(0))
+				})
+
+				ginkgo.It("does not save the message when an OCC conflict occurs", func() {
+					err := persistence.WithTransaction(
+						tc.Context,
+						dataStore,
+						func(tx persistence.ManagedTransaction) error {
+							err := tx.IncrementAggregateRevision(
+								tc.Context,
+								"<handler-key>",
+								"<instance>",
+								123,
+							)
+							gomega.Expect(err).To(gomega.Equal(aggregatestore.ErrConflict))
+							return nil // let the transaction commit despite error
+						},
+					)
+					gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+
+					rev := loadRevision(tc.Context, repository, "<handler-key>", "<instance>")
+					gomega.Expect(rev).To(gomega.BeEquivalentTo(0))
+				})
+			})
+
+			ginkgo.When("the instance exists", func() {
+				ginkgo.BeforeEach(func() {
+					incrementRevision(
+						tc.Context,
+						dataStore,
+						"<handler-key>",
+						"<instance>",
+						0,
+					)
+				})
+
+				ginkgo.It("increments the revision", func() {
+					incrementRevision(
+						tc.Context,
+						dataStore,
+						"<handler-key>",
+						"<instance>",
+						1,
+					)
+
+					rev := loadRevision(tc.Context, repository, "<handler-key>", "<instance>")
+					gomega.Expect(rev).To(gomega.BeEquivalentTo(2))
+				})
+
+				ginkgo.It("does not update the message if the transaction is rolled-back", func() {
+					err := common.WithTransactionRollback(
+						tc.Context,
+						dataStore,
+						func(tx persistence.ManagedTransaction) error {
+							return tx.IncrementAggregateRevision(
+								tc.Context,
+								"<handler-key>",
+								"<instance>",
+								1,
+							)
+						},
+					)
+					gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+
+					rev := loadRevision(tc.Context, repository, "<handler-key>", "<instance>")
+					gomega.Expect(rev).To(gomega.BeEquivalentTo(1))
+				})
+
+				table.XDescribeTable(
+					"it does not increment the revision when an OCC conflict occurs",
+					func(conflictingRevision aggregatestore.Revision) {
+						// Increment the revision once more so that it's up to
+						// revision 2. Otherwise we can't test for 1 as a
+						// too-low value.
+						incrementRevision(
+							tc.Context,
+							dataStore,
+							"<handler-key>",
+							"<instance>",
+							1,
+						)
+
+						err := persistence.WithTransaction(
+							tc.Context,
+							dataStore,
+							func(tx persistence.ManagedTransaction) error {
+								err := tx.IncrementAggregateRevision(
+									tc.Context,
+									"<handler-key>",
+									"<instance>",
+									conflictingRevision,
+								)
+								gomega.Expect(err).To(gomega.Equal(aggregatestore.ErrConflict))
+
+								return nil // let the transaction commit despite error
+							},
+						)
+						gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+
+						rev := loadRevision(tc.Context, repository, "<handler-key>", "<instance>")
+						gomega.Expect(rev).To(gomega.BeEquivalentTo(1))
+					},
+					table.Entry("zero", 0),
+					table.Entry("too low", 1),
+					table.Entry("too high", 100),
+				)
+			})
+
+			ginkgo.When("an instance's revision is incremented more than once in the same transaction", func() {
+				ginkgo.It("saves the highest revision", func() {
+					err := persistence.WithTransaction(
+						tc.Context,
+						dataStore,
+						func(tx persistence.ManagedTransaction) error {
+							if err := tx.IncrementAggregateRevision(
+								tc.Context,
+								"<handler-key>",
+								"<instance>",
+								0,
+							); err != nil {
+								return err
+							}
+
+							return tx.IncrementAggregateRevision(
+								tc.Context,
+								"<handler-key>",
+								"<instance>",
+								1,
+							)
+						},
+					)
+					gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+
+					rev := loadRevision(tc.Context, repository, "<handler-key>", "<instance>")
+					gomega.Expect(rev).To(gomega.BeEquivalentTo(2))
+				})
+
+				ginkgo.It("uses the uncommitted revision for OCC checks", func() {
+					err := common.WithTransactionRollback(
+						tc.Context,
+						dataStore,
+						func(tx persistence.ManagedTransaction) error {
+							if err := tx.IncrementAggregateRevision(
+								tc.Context,
+								"<handler-key>",
+								"<instance>",
+								0,
+							); err != nil {
+								return err
+							}
+
+							// Note that we are passing the same revision again.
+							return tx.IncrementAggregateRevision(
+								tc.Context,
+								"<handler-key>",
+								"<instance>",
+								0,
+							)
+						},
+					)
+					gomega.Expect(err).To(gomega.Equal(queuestore.ErrConflict))
+				})
+			})
+
+			ginkgo.It("serializes operations from competing transactions", func() {
+				ginkgo.By("running several transactions in parallel")
+
+				var g sync.WaitGroup
+
+				fn := func(hk, id string, count int) {
+					defer ginkgo.GinkgoRecover()
+					defer g.Done()
+
+					err := persistence.WithTransaction(
+						tc.Context,
+						dataStore,
+						func(tx persistence.ManagedTransaction) error {
+							for i := 0; i < count; i++ {
+								if err := tx.IncrementAggregateRevision(
+									tc.Context,
+									"<handler-key>",
+									"<instance>",
+									aggregatestore.Revision(count),
+								); err != nil {
+									return err
+								}
+							}
+
+							return nil
+						},
+					)
+					gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+				}
+
+				// Note the overlap of handler keys and instance IDs.
+				g.Add(3)
+				go fn("<handler-key-1>", "<instance-a>", 1)
+				go fn("<handler-key-1>", "<instance-b>", 2)
+				go fn("<handler-key-2>", "<instance-a>", 3)
+				g.Wait()
+
+				rev := loadRevision(tc.Context, repository, "<handler-key-1>", "<instance-a>")
+				gomega.Expect(rev).To(gomega.BeEquivalentTo(1))
+
+				rev = loadRevision(tc.Context, repository, "<handler-key-1>", "<instance-b>")
+				gomega.Expect(rev).To(gomega.BeEquivalentTo(2))
+
+				rev = loadRevision(tc.Context, repository, "<handler-key-2>", "<instance-a>")
+				gomega.Expect(rev).To(gomega.BeEquivalentTo(3))
+			})
+		})
+	})
+}

--- a/persistence/internal/providertest/aggregatestore/transaction.go
+++ b/persistence/internal/providertest/aggregatestore/transaction.go
@@ -33,7 +33,7 @@ func DeclareTransactionTests(tc *common.TestContext) {
 
 		ginkgo.Describe("func IncrementAggregateRevision()", func() {
 			ginkgo.When("the instance does not exist", func() {
-				ginkgo.XIt("sets the revision to 1", func() {
+				ginkgo.It("sets the revision to 1", func() {
 					incrementRevision(
 						tc.Context,
 						dataStore,

--- a/persistence/internal/providertest/aggregatestore/util.go
+++ b/persistence/internal/providertest/aggregatestore/util.go
@@ -1,0 +1,39 @@
+package aggregatestore
+
+import (
+	"context"
+
+	"github.com/dogmatiq/infix/persistence"
+	"github.com/dogmatiq/infix/persistence/subsystem/aggregatestore"
+	"github.com/onsi/gomega"
+)
+
+// loadRevision loads an aggregate instance revision.
+func loadRevision(
+	ctx context.Context,
+	r aggregatestore.Repository,
+	hk, id string,
+) aggregatestore.Revision {
+	rev, err := r.LoadRevision(ctx, hk, id)
+	gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+
+	return rev
+}
+
+// incrementRevision increments the revision of an aggregate instance.
+func incrementRevision(
+	ctx context.Context,
+	ds persistence.DataStore,
+	hk, id string,
+	c aggregatestore.Revision,
+) {
+	err := persistence.WithTransaction(
+		ctx,
+		ds,
+		func(tx persistence.ManagedTransaction) error {
+			return tx.IncrementAggregateRevision(ctx, hk, id, c)
+		},
+	)
+
+	gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+}

--- a/persistence/internal/providertest/datastore.go
+++ b/persistence/internal/providertest/datastore.go
@@ -42,6 +42,13 @@ func declareDataStoreTests(
 			}
 		})
 
+		ginkgo.Describe("func AggregateStoreRepository()", func() {
+			ginkgo.It("returns a non-nil repository", func() {
+				r := dataStore.AggregateStoreRepository()
+				gomega.Expect(r).NotTo(gomega.BeNil())
+			})
+		})
+
 		ginkgo.Describe("func EventStoreRepository()", func() {
 			ginkgo.It("returns a non-nil repository", func() {
 				r := dataStore.EventStoreRepository()

--- a/persistence/internal/providertest/suite.go
+++ b/persistence/internal/providertest/suite.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/dogmatiq/infix/persistence/internal/providertest/aggregatestore"
 	"github.com/dogmatiq/infix/persistence/internal/providertest/common"
 	"github.com/dogmatiq/infix/persistence/internal/providertest/eventstore"
 	"github.com/dogmatiq/infix/persistence/internal/providertest/queuestore"
@@ -57,6 +58,8 @@ func Declare(
 
 			cancel()
 		})
+
+		aggregatestore.DeclareRepositoryTests(&tc)
 
 		eventstore.DeclareRepositoryTests(&tc)
 		eventstore.DeclareTransactionTests(&tc)

--- a/persistence/internal/providertest/suite.go
+++ b/persistence/internal/providertest/suite.go
@@ -60,6 +60,7 @@ func Declare(
 		})
 
 		aggregatestore.DeclareRepositoryTests(&tc)
+		aggregatestore.DeclareTransactionTests(&tc)
 
 		eventstore.DeclareRepositoryTests(&tc)
 		eventstore.DeclareTransactionTests(&tc)

--- a/persistence/internal/providertest/transaction.go
+++ b/persistence/internal/providertest/transaction.go
@@ -54,6 +54,13 @@ func declareTransactionTests(
 				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 			})
 
+			ginkgo.Describe("func IncrementAggregateRevision()", func() {
+				ginkgo.It("returns an error", func() {
+					err := transaction.IncrementAggregateRevision(*ctx, "<handler-key>", "<instance>", 0)
+					gomega.Expect(err).To(gomega.Equal(persistence.ErrTransactionClosed))
+				})
+			})
+
 			ginkgo.Describe("func SaveEvent()", func() {
 				ginkgo.It("returns an error", func() {
 					_, err := transaction.SaveEvent(*ctx, &envelopespec.Envelope{})
@@ -94,6 +101,13 @@ func declareTransactionTests(
 			ginkgo.BeforeEach(func() {
 				err := transaction.Rollback()
 				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+			})
+
+			ginkgo.Describe("func IncrementAggregateRevision()", func() {
+				ginkgo.It("returns an error", func() {
+					err := transaction.IncrementAggregateRevision(*ctx, "<handler-key>", "<instance>", 0)
+					gomega.Expect(err).To(gomega.Equal(persistence.ErrTransactionClosed))
+				})
 			})
 
 			ginkgo.Describe("func SaveEvent()", func() {

--- a/persistence/provider/boltdb/aggregatestore.go
+++ b/persistence/provider/boltdb/aggregatestore.go
@@ -38,8 +38,8 @@ var (
 // ak is the aggregate handler's identity key, id is the instance ID.
 //
 // c must be the instance's current revision as persisted, otherwise an
-// optimistic concurrency conflict has occurred, the revision is not saved
-// and ErrConflict is returned.
+// optimistic concurrency conflict has occurred, the revision is not saved and
+// ErrConflict is returned.
 func (t *transaction) IncrementAggregateRevision(
 	ctx context.Context,
 	hk string,

--- a/persistence/provider/boltdb/aggregatestore.go
+++ b/persistence/provider/boltdb/aggregatestore.go
@@ -23,3 +23,18 @@ func (t *transaction) IncrementAggregateRevision(
 ) error {
 	return errors.New("not implemented")
 }
+
+// aggregateStoreRepository is an implementation of aggregatestore.Repository
+// that stores aggregate state in a BoltDB database.
+type aggregateStoreRepository struct {
+}
+
+// LoadRevision loads the current revision of an aggregate instance.
+//
+// ak is the aggregate handler's identity key, id is the instance ID.
+func (r *aggregateStoreRepository) LoadRevision(
+	ctx context.Context,
+	hk, id string,
+) (aggregatestore.Revision, error) {
+	return 0, errors.New("not implemented")
+}

--- a/persistence/provider/boltdb/aggregatestore.go
+++ b/persistence/provider/boltdb/aggregatestore.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 
+	"github.com/dogmatiq/infix/internal/x/bboltx"
 	"github.com/dogmatiq/infix/persistence/subsystem/aggregatestore"
 )
 
@@ -20,7 +21,13 @@ func (t *transaction) IncrementAggregateRevision(
 	hk string,
 	id string,
 	c aggregatestore.Revision,
-) error {
+) (err error) {
+	defer bboltx.Recover(&err)
+
+	if err := t.begin(ctx); err != nil {
+		return err
+	}
+
 	return errors.New("not implemented")
 }
 

--- a/persistence/provider/boltdb/aggregatestore.go
+++ b/persistence/provider/boltdb/aggregatestore.go
@@ -1,0 +1,25 @@
+package boltdb
+
+import (
+	"context"
+	"errors"
+
+	"github.com/dogmatiq/infix/persistence/subsystem/aggregatestore"
+)
+
+// IncrementAggregateRevision increments the persisted revision of a an
+// aggregate instance.
+//
+// ak is the aggregate handler's identity key, id is the instance ID.
+//
+// c must be the instance's current revision as persisted, otherwise an
+// optimistic concurrency conflict has occurred, the revision is not saved
+// and ErrConflict is returned.
+func (t *transaction) IncrementAggregateRevision(
+	ctx context.Context,
+	hk string,
+	id string,
+	c aggregatestore.Revision,
+) error {
+	return errors.New("not implemented")
+}

--- a/persistence/provider/boltdb/datastore.go
+++ b/persistence/provider/boltdb/datastore.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 
 	"github.com/dogmatiq/infix/persistence"
+	"github.com/dogmatiq/infix/persistence/subsystem/aggregatestore"
 	"github.com/dogmatiq/infix/persistence/subsystem/eventstore"
 	"github.com/dogmatiq/infix/persistence/subsystem/queuestore"
 )
@@ -29,6 +30,11 @@ func newDataStore(
 		appKey:  []byte(k),
 		release: r,
 	}
+}
+
+// AggregateStoreRepository returns application's aggregate store repository.
+func (ds *dataStore) AggregateStoreRepository() aggregatestore.Repository {
+	panic("not implemented")
 }
 
 // EventStoreRepository returns the application's event store repository.

--- a/persistence/provider/boltdb/datastore.go
+++ b/persistence/provider/boltdb/datastore.go
@@ -34,7 +34,7 @@ func newDataStore(
 
 // AggregateStoreRepository returns application's aggregate store repository.
 func (ds *dataStore) AggregateStoreRepository() aggregatestore.Repository {
-	return &aggregateStoreRepository{}
+	return &aggregateStoreRepository{ds.db, ds.appKey}
 }
 
 // EventStoreRepository returns the application's event store repository.

--- a/persistence/provider/boltdb/datastore.go
+++ b/persistence/provider/boltdb/datastore.go
@@ -34,7 +34,7 @@ func newDataStore(
 
 // AggregateStoreRepository returns application's aggregate store repository.
 func (ds *dataStore) AggregateStoreRepository() aggregatestore.Repository {
-	panic("not implemented")
+	return &aggregateStoreRepository{}
 }
 
 // EventStoreRepository returns the application's event store repository.

--- a/persistence/provider/memory/aggregatestore.go
+++ b/persistence/provider/memory/aggregatestore.go
@@ -31,6 +31,7 @@ func (t *transaction) IncrementAggregateRevision(
 // aggregateStoreRepository is an implementation of aggregatestore.Repository
 // that stores aggregate state in memory.
 type aggregateStoreRepository struct {
+	db *database
 }
 
 // LoadRevision loads the current revision of an aggregate instance.
@@ -40,5 +41,15 @@ func (r *aggregateStoreRepository) LoadRevision(
 	ctx context.Context,
 	hk, id string,
 ) (aggregatestore.Revision, error) {
-	return 0, errors.New("not implemented")
+	if err := r.db.RLock(ctx); err != nil {
+		return 0, err
+	}
+	defer r.db.RUnlock()
+
+	return r.db.aggregate.revisions[hk][id], nil
+}
+
+// aggregateStoreDatabase contains data that is committed to the aggregate store.
+type aggregateStoreDatabase struct {
+	revisions map[string]map[string]aggregatestore.Revision
 }

--- a/persistence/provider/memory/aggregatestore.go
+++ b/persistence/provider/memory/aggregatestore.go
@@ -21,6 +21,10 @@ func (t *transaction) IncrementAggregateRevision(
 	id string,
 	c aggregatestore.Revision,
 ) error {
+	if err := t.begin(ctx); err != nil {
+		return err
+	}
+
 	return errors.New("not implemented")
 }
 

--- a/persistence/provider/memory/aggregatestore.go
+++ b/persistence/provider/memory/aggregatestore.go
@@ -2,7 +2,6 @@ package memory
 
 import (
 	"context"
-	"errors"
 
 	"github.com/dogmatiq/infix/persistence/subsystem/aggregatestore"
 )
@@ -25,7 +24,11 @@ func (t *transaction) IncrementAggregateRevision(
 		return err
 	}
 
-	return errors.New("not implemented")
+	if t.aggregate.stageIncrement(&t.ds.db.aggregate, hk, id, c) {
+		return nil
+	}
+
+	return aggregatestore.ErrConflict
 }
 
 // aggregateStoreRepository is an implementation of aggregatestore.Repository
@@ -49,7 +52,78 @@ func (r *aggregateStoreRepository) LoadRevision(
 	return r.db.aggregate.revisions[hk][id], nil
 }
 
+// aggregateStoreChangeSet contains modifications to the aggregate store that have
+// been performed within a transaction but not yet committed.
+type aggregateStoreChangeSet struct {
+	revisions map[string]map[string]aggregatestore.Revision
+}
+
+// stageIncrement adds a "IncrementAggregateRevision" operation to the
+// change-set.
+//
+// It returns false if there is an OCC conflict.
+func (cs *aggregateStoreChangeSet) stageIncrement(
+	db *aggregateStoreDatabase,
+	hk string,
+	id string,
+	c aggregatestore.Revision,
+) bool {
+	// Capture the instance ID -> revision map once for this handler to avoid
+	// minimize the number of lookups in cs.revisions.
+	instances := cs.revisions[hk]
+
+	// Get both the committed item, and the item as it appears with its changes
+	// staged in this change-set.
+	committed := db.revisions[hk][id]
+	staged, changed := instances[id]
+
+	// The "effective" revision is how the revision appears to this transaction.
+	effective := committed
+	if changed {
+		effective = staged
+	}
+
+	// Enforce the optimistic concurrency control requirements.
+	if c != effective {
+		return false
+	}
+
+	// Add the incremented revision to the change-set.
+	if instances == nil {
+		instances = map[string]aggregatestore.Revision{}
+
+		if cs.revisions == nil {
+			cs.revisions = map[string]map[string]aggregatestore.Revision{}
+		}
+		cs.revisions[hk] = instances
+	}
+
+	instances[id] = effective + 1
+
+	return true
+}
+
 // aggregateStoreDatabase contains data that is committed to the aggregate store.
 type aggregateStoreDatabase struct {
 	revisions map[string]map[string]aggregatestore.Revision
+}
+
+// apply updates the database to include the changes in cs.
+func (db *aggregateStoreDatabase) apply(cs *aggregateStoreChangeSet) {
+	for hk, instances := range cs.revisions {
+		committed := db.revisions[hk]
+
+		if committed == nil {
+			committed = map[string]aggregatestore.Revision{}
+
+			if db.revisions == nil {
+				db.revisions = map[string]map[string]aggregatestore.Revision{}
+			}
+			db.revisions[hk] = committed
+		}
+
+		for id, rev := range instances {
+			committed[id] = rev
+		}
+	}
 }

--- a/persistence/provider/memory/aggregatestore.go
+++ b/persistence/provider/memory/aggregatestore.go
@@ -1,0 +1,25 @@
+package memory
+
+import (
+	"context"
+	"errors"
+
+	"github.com/dogmatiq/infix/persistence/subsystem/aggregatestore"
+)
+
+// IncrementAggregateRevision increments the persisted revision of a an
+// aggregate instance.
+//
+// ak is the aggregate handler's identity key, id is the instance ID.
+//
+// c must be the instance's current revision as persisted, otherwise an
+// optimistic concurrency conflict has occurred, the revision is not saved
+// and ErrConflict is returned.
+func (t *transaction) IncrementAggregateRevision(
+	ctx context.Context,
+	hk string,
+	id string,
+	c aggregatestore.Revision,
+) error {
+	return errors.New("not implemented")
+}

--- a/persistence/provider/memory/aggregatestore.go
+++ b/persistence/provider/memory/aggregatestore.go
@@ -23,3 +23,18 @@ func (t *transaction) IncrementAggregateRevision(
 ) error {
 	return errors.New("not implemented")
 }
+
+// aggregateStoreRepository is an implementation of aggregatestore.Repository
+// that stores aggregate state in memory.
+type aggregateStoreRepository struct {
+}
+
+// LoadRevision loads the current revision of an aggregate instance.
+//
+// ak is the aggregate handler's identity key, id is the instance ID.
+func (r *aggregateStoreRepository) LoadRevision(
+	ctx context.Context,
+	hk, id string,
+) (aggregatestore.Revision, error) {
+	return 0, errors.New("not implemented")
+}

--- a/persistence/provider/memory/aggregatestore.go
+++ b/persistence/provider/memory/aggregatestore.go
@@ -13,8 +13,8 @@ import (
 // ak is the aggregate handler's identity key, id is the instance ID.
 //
 // c must be the instance's current revision as persisted, otherwise an
-// optimistic concurrency conflict has occurred, the revision is not saved
-// and ErrConflict is returned.
+// optimistic concurrency conflict has occurred, the revision is not saved and
+// ErrConflict is returned.
 func (t *transaction) IncrementAggregateRevision(
 	ctx context.Context,
 	hk string,

--- a/persistence/provider/memory/database.go
+++ b/persistence/provider/memory/database.go
@@ -12,9 +12,10 @@ import (
 type database struct {
 	syncx.RWMutex
 
-	open  uint32 // atomic
-	event eventStoreDatabase
-	queue queueStoreDatabase
+	open      uint32 // atomic
+	aggregate aggregateStoreDatabase
+	event     eventStoreDatabase
+	queue     queueStoreDatabase
 }
 
 // newDatabase returns a new empty database.

--- a/persistence/provider/memory/datastore.go
+++ b/persistence/provider/memory/datastore.go
@@ -5,6 +5,7 @@ import (
 	"sync/atomic"
 
 	"github.com/dogmatiq/infix/persistence"
+	"github.com/dogmatiq/infix/persistence/subsystem/aggregatestore"
 	"github.com/dogmatiq/infix/persistence/subsystem/eventstore"
 	"github.com/dogmatiq/infix/persistence/subsystem/queuestore"
 )
@@ -21,6 +22,11 @@ func newDataStore(db *database) *dataStore {
 	return &dataStore{
 		db: db,
 	}
+}
+
+// AggregateStoreRepository returns application's aggregate store repository.
+func (ds *dataStore) AggregateStoreRepository() aggregatestore.Repository {
+	panic("not implemented")
 }
 
 // EventStoreRepository returns the application's event store repository.

--- a/persistence/provider/memory/datastore.go
+++ b/persistence/provider/memory/datastore.go
@@ -26,7 +26,7 @@ func newDataStore(db *database) *dataStore {
 
 // AggregateStoreRepository returns application's aggregate store repository.
 func (ds *dataStore) AggregateStoreRepository() aggregatestore.Repository {
-	panic("not implemented")
+	return &aggregateStoreRepository{}
 }
 
 // EventStoreRepository returns the application's event store repository.

--- a/persistence/provider/memory/datastore.go
+++ b/persistence/provider/memory/datastore.go
@@ -26,7 +26,7 @@ func newDataStore(db *database) *dataStore {
 
 // AggregateStoreRepository returns application's aggregate store repository.
 func (ds *dataStore) AggregateStoreRepository() aggregatestore.Repository {
-	return &aggregateStoreRepository{}
+	return &aggregateStoreRepository{ds.db}
 }
 
 // EventStoreRepository returns the application's event store repository.

--- a/persistence/provider/memory/eventstore.go
+++ b/persistence/provider/memory/eventstore.go
@@ -94,7 +94,7 @@ type eventStoreChangeSet struct {
 	items []*eventstore.Item
 }
 
-// stageSave adds a "SaveEvent" to the change-set.
+// stageSave adds a "SaveEvent" operation to the change-set.
 func (cs *eventStoreChangeSet) stageSave(
 	db *eventStoreDatabase,
 	env *envelopespec.Envelope,

--- a/persistence/provider/memory/queuestore.go
+++ b/persistence/provider/memory/queuestore.go
@@ -111,7 +111,7 @@ func (cs *queueStoreChangeSet) stageSave(
 		effectiveRev = effective.Revision
 	}
 
-	// Enforce the optimistic concurrenct control requirements.
+	// Enforce the optimistic concurrency control requirements.
 	if i.Revision != effectiveRev {
 		return false
 	}
@@ -158,7 +158,7 @@ func (cs *queueStoreChangeSet) stageRemove(
 		effective = staged
 	}
 
-	// Enforce the optimistic concurrenct control requirements.
+	// Enforce the optimistic concurrency control requirements.
 	//
 	// effective will be nil if the item is already staged for removal, in which
 	// case from the perspective of this transaction it's trying to remove a

--- a/persistence/provider/memory/transaction.go
+++ b/persistence/provider/memory/transaction.go
@@ -9,10 +9,11 @@ import (
 // transaction is an implementation of persistence.Transaction for in-memory
 // data stores.
 type transaction struct {
-	ds      *dataStore
-	hasLock bool
-	event   eventStoreChangeSet
-	queue   queueStoreChangeSet
+	ds        *dataStore
+	hasLock   bool
+	aggregate aggregateStoreChangeSet
+	event     eventStoreChangeSet
+	queue     queueStoreChangeSet
 }
 
 // Commit applies the changes from the transaction.
@@ -31,6 +32,7 @@ func (t *transaction) Commit(ctx context.Context) error {
 		return nil
 	}
 
+	t.ds.db.aggregate.apply(&t.aggregate)
 	t.ds.db.event.apply(&t.event)
 	t.ds.db.queue.apply(&t.queue)
 

--- a/persistence/provider/sql/aggregatestore.go
+++ b/persistence/provider/sql/aggregatestore.go
@@ -30,6 +30,13 @@ type aggregateStoreDriver interface {
 		ak, hk, id string,
 		rev aggregatestore.Revision,
 	) (bool, error)
+
+	// SelectAggregateRevision selects an aggregate instance's revision.
+	SelectAggregateRevision(
+		ctx context.Context,
+		db *sql.DB,
+		ak, hk, id string,
+	) (aggregatestore.Revision, error)
 }
 
 // IncrementAggregateRevision increments the persisted revision of a an

--- a/persistence/provider/sql/aggregatestore.go
+++ b/persistence/provider/sql/aggregatestore.go
@@ -21,6 +21,10 @@ func (t *transaction) IncrementAggregateRevision(
 	id string,
 	c aggregatestore.Revision,
 ) error {
+	if err := t.begin(ctx); err != nil {
+		return err
+	}
+
 	return errors.New("not implemented")
 }
 

--- a/persistence/provider/sql/aggregatestore.go
+++ b/persistence/provider/sql/aggregatestore.go
@@ -23,3 +23,18 @@ func (t *transaction) IncrementAggregateRevision(
 ) error {
 	return errors.New("not implemented")
 }
+
+// aggregateStoreRepository is an implementation of aggregatestore.Repository
+// that stores aggregate state in an SQL database.
+type aggregateStoreRepository struct {
+}
+
+// LoadRevision loads the current revision of an aggregate instance.
+//
+// ak is the aggregate handler's identity key, id is the instance ID.
+func (r *aggregateStoreRepository) LoadRevision(
+	ctx context.Context,
+	hk, id string,
+) (aggregatestore.Revision, error) {
+	return 0, errors.New("not implemented")
+}

--- a/persistence/provider/sql/aggregatestore.go
+++ b/persistence/provider/sql/aggregatestore.go
@@ -1,0 +1,25 @@
+package sql
+
+import (
+	"context"
+	"errors"
+
+	"github.com/dogmatiq/infix/persistence/subsystem/aggregatestore"
+)
+
+// IncrementAggregateRevision increments the persisted revision of a an
+// aggregate instance.
+//
+// ak is the aggregate handler's identity key, id is the instance ID.
+//
+// c must be the instance's current revision as persisted, otherwise an
+// optimistic concurrency conflict has occurred, the revision is not saved
+// and ErrConflict is returned.
+func (t *transaction) IncrementAggregateRevision(
+	ctx context.Context,
+	hk string,
+	id string,
+	c aggregatestore.Revision,
+) error {
+	return errors.New("not implemented")
+}

--- a/persistence/provider/sql/aggregatestore.go
+++ b/persistence/provider/sql/aggregatestore.go
@@ -63,6 +63,9 @@ func (t *transaction) IncrementAggregateRevision(
 // aggregateStoreRepository is an implementation of aggregatestore.Repository
 // that stores aggregate state in an SQL database.
 type aggregateStoreRepository struct {
+	db     *sql.DB
+	driver Driver
+	appKey string
 }
 
 // LoadRevision loads the current revision of an aggregate instance.
@@ -72,5 +75,5 @@ func (r *aggregateStoreRepository) LoadRevision(
 	ctx context.Context,
 	hk, id string,
 ) (aggregatestore.Revision, error) {
-	return 0, errors.New("not implemented")
+	return r.driver.SelectAggregateRevision(ctx, r.db, r.appKey, hk, id)
 }

--- a/persistence/provider/sql/aggregatestore.go
+++ b/persistence/provider/sql/aggregatestore.go
@@ -45,8 +45,8 @@ type aggregateStoreDriver interface {
 // ak is the aggregate handler's identity key, id is the instance ID.
 //
 // c must be the instance's current revision as persisted, otherwise an
-// optimistic concurrency conflict has occurred, the revision is not saved
-// and ErrConflict is returned.
+// optimistic concurrency conflict has occurred, the revision is not saved and
+// ErrConflict is returned.
 func (t *transaction) IncrementAggregateRevision(
 	ctx context.Context,
 	hk string,

--- a/persistence/provider/sql/aggregatestore.go
+++ b/persistence/provider/sql/aggregatestore.go
@@ -2,10 +2,35 @@ package sql
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 
 	"github.com/dogmatiq/infix/persistence/subsystem/aggregatestore"
 )
+
+// aggregateStoreDriver is the subset of the Driver interface that is concerned
+// with the aggregatestore subsystem.
+type aggregateStoreDriver interface {
+	// InsertAggregateRevision inserts an aggregate revision for an aggregate
+	// instance.
+	//
+	// It returns false if the row already exists.
+	InsertAggregateRevision(
+		ctx context.Context,
+		tx *sql.Tx,
+		ak, hk, id string,
+	) (bool, error)
+
+	// UpdateAggregateRevision increments an aggregate isntance's revision by 1.
+	//
+	// It returns false if the row does not exist or rev is not current.
+	UpdateAggregateRevision(
+		ctx context.Context,
+		tx *sql.Tx,
+		ak, hk, id string,
+		rev aggregatestore.Revision,
+	) (bool, error)
+}
 
 // IncrementAggregateRevision increments the persisted revision of a an
 // aggregate instance.

--- a/persistence/provider/sql/datastore.go
+++ b/persistence/provider/sql/datastore.go
@@ -38,7 +38,7 @@ func newDataStore(
 
 // AggregateStoreRepository returns application's aggregate store repository.
 func (ds *dataStore) AggregateStoreRepository() aggregatestore.Repository {
-	return &aggregateStoreRepository{}
+	return &aggregateStoreRepository{ds.db, ds.driver, ds.appKey}
 }
 
 // EventStoreRepository returns the application's event store repository.

--- a/persistence/provider/sql/datastore.go
+++ b/persistence/provider/sql/datastore.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 
 	"github.com/dogmatiq/infix/persistence"
+	"github.com/dogmatiq/infix/persistence/subsystem/aggregatestore"
 	"github.com/dogmatiq/infix/persistence/subsystem/eventstore"
 	"github.com/dogmatiq/infix/persistence/subsystem/queuestore"
 )
@@ -33,6 +34,11 @@ func newDataStore(
 		appKey:  k,
 		release: r,
 	}
+}
+
+// AggregateStoreRepository returns application's aggregate store repository.
+func (ds *dataStore) AggregateStoreRepository() aggregatestore.Repository {
+	panic("not implemented")
 }
 
 // EventStoreRepository returns the application's event store repository.

--- a/persistence/provider/sql/datastore.go
+++ b/persistence/provider/sql/datastore.go
@@ -38,7 +38,7 @@ func newDataStore(
 
 // AggregateStoreRepository returns application's aggregate store repository.
 func (ds *dataStore) AggregateStoreRepository() aggregatestore.Repository {
-	panic("not implemented")
+	return &aggregateStoreRepository{}
 }
 
 // EventStoreRepository returns the application's event store repository.

--- a/persistence/provider/sql/driver.go
+++ b/persistence/provider/sql/driver.go
@@ -12,6 +12,7 @@ import (
 
 // Driver is used to interface with the underlying SQL database.
 type Driver interface {
+	aggregateStoreDriver
 	eventStoreDriver
 	queueDriver
 

--- a/persistence/provider/sql/mysql/aggregatestore.go
+++ b/persistence/provider/sql/mysql/aggregatestore.go
@@ -1,0 +1,33 @@
+package mysql
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+
+	"github.com/dogmatiq/infix/persistence/subsystem/aggregatestore"
+)
+
+// InsertAggregateRevision inserts an aggregate revision for an aggregate
+// instance.
+//
+// It returns false if the row already exists.
+func (driver) InsertAggregateRevision(
+	ctx context.Context,
+	tx *sql.Tx,
+	ak, hk, id string,
+) (bool, error) {
+	return false, errors.New("not implemented")
+}
+
+// UpdateAggregateRevision increments an aggregate isntance's revision by 1.
+//
+// It returns false if the row does not exist or rev is not current.
+func (driver) UpdateAggregateRevision(
+	ctx context.Context,
+	tx *sql.Tx,
+	ak, hk, id string,
+	rev aggregatestore.Revision,
+) (bool, error) {
+	return false, errors.New("not implemented")
+}

--- a/persistence/provider/sql/mysql/aggregatestore.go
+++ b/persistence/provider/sql/mysql/aggregatestore.go
@@ -38,5 +38,25 @@ func (driver) SelectAggregateRevision(
 	db *sql.DB,
 	ak, hk, id string,
 ) (aggregatestore.Revision, error) {
-	return 0, errors.New("not implemented")
+	row := db.QueryRowContext(
+		ctx,
+		`SELECT
+			r.revision
+		FROM aggregate_revision AS r
+		WHERE app_key = ?
+		AND handler_key = ?
+		AND instance_id = ?`,
+		ak,
+		hk,
+		id,
+	)
+
+	var rev aggregatestore.Revision
+	err := row.Scan(&rev)
+
+	if err == sql.ErrNoRows {
+		return 0, nil
+	}
+
+	return rev, err
 }

--- a/persistence/provider/sql/mysql/aggregatestore.go
+++ b/persistence/provider/sql/mysql/aggregatestore.go
@@ -31,3 +31,12 @@ func (driver) UpdateAggregateRevision(
 ) (bool, error) {
 	return false, errors.New("not implemented")
 }
+
+// SelectAggregateRevision selects an aggregate instance's revision.
+func (driver) SelectAggregateRevision(
+	ctx context.Context,
+	db *sql.DB,
+	ak, hk, id string,
+) (aggregatestore.Revision, error) {
+	return 0, errors.New("not implemented")
+}

--- a/persistence/provider/sql/postgres/aggregatestore.go
+++ b/persistence/provider/sql/postgres/aggregatestore.go
@@ -1,0 +1,33 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+
+	"github.com/dogmatiq/infix/persistence/subsystem/aggregatestore"
+)
+
+// InsertAggregateRevision inserts an aggregate revision for an aggregate
+// instance.
+//
+// It returns false if the row already exists.
+func (driver) InsertAggregateRevision(
+	ctx context.Context,
+	tx *sql.Tx,
+	ak, hk, id string,
+) (bool, error) {
+	return false, errors.New("not implemented")
+}
+
+// UpdateAggregateRevision increments an aggregate isntance's revision by 1.
+//
+// It returns false if the row does not exist or rev is not current.
+func (driver) UpdateAggregateRevision(
+	ctx context.Context,
+	tx *sql.Tx,
+	ak, hk, id string,
+	rev aggregatestore.Revision,
+) (bool, error) {
+	return false, errors.New("not implemented")
+}

--- a/persistence/provider/sql/postgres/aggregatestore.go
+++ b/persistence/provider/sql/postgres/aggregatestore.go
@@ -31,3 +31,12 @@ func (driver) UpdateAggregateRevision(
 ) (bool, error) {
 	return false, errors.New("not implemented")
 }
+
+// SelectAggregateRevision selects an aggregate instance's revision.
+func (driver) SelectAggregateRevision(
+	ctx context.Context,
+	db *sql.DB,
+	ak, hk, id string,
+) (aggregatestore.Revision, error) {
+	return 0, errors.New("not implemented")
+}

--- a/persistence/provider/sql/postgres/aggregatestore.go
+++ b/persistence/provider/sql/postgres/aggregatestore.go
@@ -38,5 +38,25 @@ func (driver) SelectAggregateRevision(
 	db *sql.DB,
 	ak, hk, id string,
 ) (aggregatestore.Revision, error) {
-	return 0, errors.New("not implemented")
+	row := db.QueryRowContext(
+		ctx,
+		`SELECT
+			r.revision
+		FROM infix.aggregate_revision AS r
+		WHERE app_key = $1
+		AND handler_key = $2
+		AND instance_id = $3`,
+		ak,
+		hk,
+		id,
+	)
+
+	var rev aggregatestore.Revision
+	err := row.Scan(&rev)
+
+	if err == sql.ErrNoRows {
+		return 0, nil
+	}
+
+	return rev, err
 }

--- a/persistence/provider/sql/postgres/aggregatestore.go
+++ b/persistence/provider/sql/postgres/aggregatestore.go
@@ -3,21 +3,39 @@ package postgres
 import (
 	"context"
 	"database/sql"
-	"errors"
 
+	"github.com/dogmatiq/infix/internal/x/sqlx"
 	"github.com/dogmatiq/infix/persistence/subsystem/aggregatestore"
 )
 
-// InsertAggregateRevision inserts an aggregate revision for an aggregate
-// instance.
+// InsertAggregateRevision inserts an aggregate revision (with a value of 1) for
+// an aggregate instance.
 //
 // It returns false if the row already exists.
 func (driver) InsertAggregateRevision(
 	ctx context.Context,
 	tx *sql.Tx,
 	ak, hk, id string,
-) (bool, error) {
-	return false, errors.New("not implemented")
+) (_ bool, err error) {
+	defer sqlx.Recover(&err)
+
+	res := sqlx.Exec(
+		ctx,
+		tx,
+		`INSERT INTO infix.aggregate_revision (
+			app_key,
+			handler_key,
+			instance_id
+		) VALUES (
+			$1, $2, $3
+		) ON CONFLICT (app_key, handler_key, instance_id) DO NOTHING`,
+		ak,
+		hk,
+		id,
+	)
+
+	n, err := res.RowsAffected()
+	return n == 1, err
 }
 
 // UpdateAggregateRevision increments an aggregate isntance's revision by 1.
@@ -28,8 +46,23 @@ func (driver) UpdateAggregateRevision(
 	tx *sql.Tx,
 	ak, hk, id string,
 	rev aggregatestore.Revision,
-) (bool, error) {
-	return false, errors.New("not implemented")
+) (_ bool, err error) {
+	defer sqlx.Recover(&err)
+
+	return sqlx.TryExecRow(
+		ctx,
+		tx,
+		`UPDATE infix.aggregate_revision SET
+			revision = revision + 1
+		WHERE app_key = $1
+		AND handler_key = $2
+		AND instance_id = $3
+		AND revision = $4`,
+		ak,
+		hk,
+		id,
+		rev,
+	), nil
 }
 
 // SelectAggregateRevision selects an aggregate instance's revision.

--- a/persistence/provider/sql/postgres/error.go
+++ b/persistence/provider/sql/postgres/error.go
@@ -91,6 +91,15 @@ func (d errorConverter) UpdateAggregateRevision(
 	return ok, convertContextErrors(ctx, err)
 }
 
+func (d errorConverter) SelectAggregateRevision(
+	ctx context.Context,
+	db *sql.DB,
+	ak, hk, id string,
+) (aggregatestore.Revision, error) {
+	rev, err := d.d.SelectAggregateRevision(ctx, db, ak, hk, id)
+	return rev, convertContextErrors(ctx, err)
+}
+
 //
 // eventstore
 //

--- a/persistence/provider/sql/postgres/error.go
+++ b/persistence/provider/sql/postgres/error.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 
 	"github.com/dogmatiq/infix/draftspecs/envelopespec"
+	"github.com/dogmatiq/infix/persistence/subsystem/aggregatestore"
 	"github.com/dogmatiq/infix/persistence/subsystem/eventstore"
 	"github.com/dogmatiq/infix/persistence/subsystem/queuestore"
 	"github.com/lib/pq"
@@ -65,6 +66,29 @@ func (d errorConverter) LockApplication(
 ) (func() error, error) {
 	r, err := d.d.LockApplication(ctx, db, ak)
 	return r, convertContextErrors(ctx, err)
+}
+
+//
+// aggregatestore
+//
+
+func (d errorConverter) InsertAggregateRevision(
+	ctx context.Context,
+	tx *sql.Tx,
+	ak, hk, id string,
+) (bool, error) {
+	ok, err := d.d.InsertAggregateRevision(ctx, tx, ak, hk, id)
+	return ok, convertContextErrors(ctx, err)
+}
+
+func (d errorConverter) UpdateAggregateRevision(
+	ctx context.Context,
+	tx *sql.Tx,
+	ak, hk, id string,
+	rev aggregatestore.Revision,
+) (bool, error) {
+	ok, err := d.d.UpdateAggregateRevision(ctx, tx, ak, hk, id, rev)
+	return ok, convertContextErrors(ctx, err)
 }
 
 //

--- a/persistence/provider/sql/postgres/queuestore.go
+++ b/persistence/provider/sql/postgres/queuestore.go
@@ -17,7 +17,6 @@ func (driver) InsertQueueMessage(
 	ak string,
 	i *queuestore.Item,
 ) (_ bool, err error) {
-
 	defer sqlx.Recover(&err)
 
 	res := sqlx.Exec(

--- a/persistence/provider/sql/postgres/schema.go
+++ b/persistence/provider/sql/postgres/schema.go
@@ -25,6 +25,7 @@ func CreateSchema(ctx context.Context, db *sql.DB) (err error) {
 		)`,
 	)
 
+	createAggregateStoreSchema(ctx, db)
 	createEventStoreSchema(ctx, db)
 	createQueueSchema(ctx, db)
 
@@ -35,6 +36,23 @@ func CreateSchema(ctx context.Context, db *sql.DB) (err error) {
 func DropSchema(ctx context.Context, db *sql.DB) error {
 	_, err := db.ExecContext(ctx, `DROP SCHEMA IF EXISTS infix CASCADE`)
 	return err
+}
+
+// createAggregateStoreSchema creates the schema elements required by the
+// aggregate store subsystem.
+func createAggregateStoreSchema(ctx context.Context, db *sql.DB) {
+	sqlx.Exec(
+		ctx,
+		db,
+		`CREATE TABLE infix.aggregate_revision (
+			app_key 	TEXT NOT NULL,
+			handler_key TEXT NOT NULL,
+			instance_id TEXT NOT NULL,
+			revision    BIGINT NOT NULL DEFAULT 1,
+
+			PRIMARY KEY (app_key, handler_key, instance_id)
+		)`,
+	)
 }
 
 // createEventStoreSchema creates the schema elements required by the event

--- a/persistence/provider/sql/sqlite/aggregatestore.go
+++ b/persistence/provider/sql/sqlite/aggregatestore.go
@@ -38,5 +38,25 @@ func (driver) SelectAggregateRevision(
 	db *sql.DB,
 	ak, hk, id string,
 ) (aggregatestore.Revision, error) {
-	return 0, errors.New("not implemented")
+	row := db.QueryRowContext(
+		ctx,
+		`SELECT
+			r.revision
+		FROM aggregate_revision AS r
+		WHERE app_key = $1
+		AND handler_key = $2
+		AND instance_id = $3`,
+		ak,
+		hk,
+		id,
+	)
+
+	var rev aggregatestore.Revision
+	err := row.Scan(&rev)
+
+	if err == sql.ErrNoRows {
+		return 0, nil
+	}
+
+	return rev, err
 }

--- a/persistence/provider/sql/sqlite/aggregatestore.go
+++ b/persistence/provider/sql/sqlite/aggregatestore.go
@@ -31,3 +31,12 @@ func (driver) UpdateAggregateRevision(
 ) (bool, error) {
 	return false, errors.New("not implemented")
 }
+
+// SelectAggregateRevision selects an aggregate instance's revision.
+func (driver) SelectAggregateRevision(
+	ctx context.Context,
+	db *sql.DB,
+	ak, hk, id string,
+) (aggregatestore.Revision, error) {
+	return 0, errors.New("not implemented")
+}

--- a/persistence/provider/sql/sqlite/aggregatestore.go
+++ b/persistence/provider/sql/sqlite/aggregatestore.go
@@ -1,0 +1,33 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+
+	"github.com/dogmatiq/infix/persistence/subsystem/aggregatestore"
+)
+
+// InsertAggregateRevision inserts an aggregate revision for an aggregate
+// instance.
+//
+// It returns false if the row already exists.
+func (driver) InsertAggregateRevision(
+	ctx context.Context,
+	tx *sql.Tx,
+	ak, hk, id string,
+) (bool, error) {
+	return false, errors.New("not implemented")
+}
+
+// UpdateAggregateRevision increments an aggregate isntance's revision by 1.
+//
+// It returns false if the row does not exist or rev is not current.
+func (driver) UpdateAggregateRevision(
+	ctx context.Context,
+	tx *sql.Tx,
+	ak, hk, id string,
+	rev aggregatestore.Revision,
+) (bool, error) {
+	return false, errors.New("not implemented")
+}

--- a/persistence/subsystem/aggregatestore/doc.go
+++ b/persistence/subsystem/aggregatestore/doc.go
@@ -1,0 +1,3 @@
+// Package aggregatestore defines an API for persisting the aggregate snapshots
+// and enforcing optimistic concurrency control requirements.
+package aggregatestore

--- a/persistence/subsystem/aggregatestore/ginkgo_test.go
+++ b/persistence/subsystem/aggregatestore/ginkgo_test.go
@@ -1,0 +1,15 @@
+package aggregatestore_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
+)
+
+func TestSuite(t *testing.T) {
+	type tag struct{}
+	gomega.RegisterFailHandler(ginkgo.Fail)
+	ginkgo.RunSpecs(t, reflect.TypeOf(tag{}).PkgPath())
+}

--- a/persistence/subsystem/aggregatestore/repository.go
+++ b/persistence/subsystem/aggregatestore/repository.go
@@ -1,0 +1,13 @@
+package aggregatestore
+
+import (
+	"context"
+)
+
+// Repository is an interface for reading persisted aggregate state.
+type Repository interface {
+	// LoadRevision loads the current revision of an aggregate instance.
+	//
+	// ak is the aggregate handler's identity key, id is the instance ID.
+	LoadRevision(ctx context.Context, hk, id string) (Revision, error)
+}

--- a/persistence/subsystem/aggregatestore/revision.go
+++ b/persistence/subsystem/aggregatestore/revision.go
@@ -1,0 +1,5 @@
+package aggregatestore
+
+// Revision is the version of an aggregate instance, used for optimistic
+// concurrency control.
+type Revision uint64

--- a/persistence/subsystem/aggregatestore/transaction.go
+++ b/persistence/subsystem/aggregatestore/transaction.go
@@ -5,9 +5,8 @@ import (
 	"errors"
 )
 
-// ErrConflict is returned by transaction operations when a persisted
-// revision can not be updated because the supplied "current" revision is
-// out of date.
+// ErrConflict is returned by transaction operations when a persisted revision
+// can not be updated because the supplied "current" revision is out of date.
 var ErrConflict = errors.New("an optimistic concurrency conflict occured while persisting to the aggregate store")
 
 // Transaction defines the primitive persistence operations for manipulating the

--- a/persistence/subsystem/aggregatestore/transaction.go
+++ b/persistence/subsystem/aggregatestore/transaction.go
@@ -1,0 +1,30 @@
+package aggregatestore
+
+import (
+	"context"
+	"errors"
+)
+
+// ErrConflict is returned by transaction operations when a persisted
+// revision can not be updated because the supplied "current" revision is
+// out of date.
+var ErrConflict = errors.New("an optimistic concurrency conflict occured while persisting to the aggregate store")
+
+// Transaction defines the primitive persistence operations for manipulating the
+// aggregate store.
+type Transaction interface {
+	// IncrementAggregateRevision increments the persisted revision of a an
+	// aggregate instance.
+	//
+	// ak is the aggregate handler's identity key, id is the instance ID.
+	//
+	// c must be the instance's current revision as persisted, otherwise an
+	// optimistic concurrency conflict has occurred, the revision is not saved
+	// and ErrConflict is returned.
+	IncrementAggregateRevision(
+		ctx context.Context,
+		hk string,
+		id string,
+		c Revision,
+	) error
+}

--- a/persistence/transaction.go
+++ b/persistence/transaction.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 
+	"github.com/dogmatiq/infix/persistence/subsystem/aggregatestore"
 	"github.com/dogmatiq/infix/persistence/subsystem/eventstore"
 	"github.com/dogmatiq/infix/persistence/subsystem/queuestore"
 )
@@ -15,6 +16,7 @@ var ErrTransactionClosed = errors.New("transaction already committed or rolled-b
 // Transaction exposes persistence operations that can be performed atomically.
 // Transactions are not safe for concurrent use.
 type Transaction interface {
+	aggregatestore.Transaction
 	eventstore.Transaction
 	queuestore.Transaction
 
@@ -28,6 +30,7 @@ type Transaction interface {
 // ManagedTransaction is a Transaction that can not be commit or rolled-back
 // directly because its life-time is managed for the user.
 type ManagedTransaction interface {
+	aggregatestore.Transaction
 	eventstore.Transaction
 	queuestore.Transaction
 }


### PR DESCRIPTION
This PR adds the `aggregatestore` package, which currently includes features for storing aggregate instance revisions for the purposes of performing OCC checks.

In the future it will be expanded to include storage of aggregate snapshots.

Partially addresses #126.