### PR TITLE
Implement an in-memory cache of aggregate instances.

### DIFF
--- a/app.go
+++ b/app.go
@@ -12,6 +12,7 @@ import (
 	"github.com/dogmatiq/infix/eventstream"
 	"github.com/dogmatiq/infix/eventstream/persistedstream"
 	"github.com/dogmatiq/infix/handler/aggregate"
+	"github.com/dogmatiq/infix/handler/cache"
 	"github.com/dogmatiq/infix/handler/integration"
 	"github.com/dogmatiq/infix/internal/x/loggingx"
 	"github.com/dogmatiq/infix/parcel"
@@ -191,6 +192,11 @@ func (f *routeFactory) VisitRichAggregate(_ context.Context, cfg configkit.RichA
 		Identity: envelopespec.MarshalIdentity(cfg.Identity()),
 		Handler:  cfg.Handler(),
 		Loader:   f.loader,
+		Cache: &cache.Cache{
+			// TODO: https://github.com/dogmatiq/infix/issues/193
+			// Make TTL configurable.
+			Logger: f.logger,
+		},
 		Packer: &parcel.Packer{
 			Application: f.app,
 			Marshaler:   f.opts.Marshaler,

--- a/handler/aggregate/pipeline.go
+++ b/handler/aggregate/pipeline.go
@@ -100,7 +100,7 @@ func (s *Sink) Accept(
 		return err
 	}
 
-	rec.MarkInstanceSaved()
+	rec.KeepAlive()
 
 	return nil
 }

--- a/handler/aggregate/pipeline.go
+++ b/handler/aggregate/pipeline.go
@@ -7,6 +7,7 @@ import (
 	"github.com/dogmatiq/dodeca/logging"
 	"github.com/dogmatiq/dogma"
 	"github.com/dogmatiq/infix/draftspecs/envelopespec"
+	"github.com/dogmatiq/infix/handler/cache"
 	"github.com/dogmatiq/infix/parcel"
 	"github.com/dogmatiq/infix/persistence/subsystem/aggregatestore"
 	"github.com/dogmatiq/infix/persistence/subsystem/eventstore"
@@ -28,6 +29,9 @@ type Sink struct {
 	// Loader is used to load aggregate instances into memory.
 	Loader *Loader
 
+	// Cache is an in-memory cache of aggregate meta-data and roots.
+	Cache *cache.Cache
+
 	// Packer is used to create new parcels for events recorded by the
 	// handler.
 	Packer *parcel.Packer
@@ -35,6 +39,13 @@ type Sink struct {
 	// Logger is the target for log messages produced within the handler.
 	// If it is nil, logging.DefaultLogger is used.
 	Logger logging.Logger
+}
+
+// instance is an in-memory representation of the aggregate instance, as stored
+// in the cache.
+type instance struct {
+	metadata *aggregatestore.MetaData
+	root     dogma.AggregateRoot
 }
 
 // Accept handles a message using s.Handler.
@@ -49,9 +60,18 @@ func (s *Sink) Accept(
 	}
 
 	id := s.route(p.Message)
-	root := s.new()
 
-	md, err := s.Loader.Load(ctx, s.Identity.Key, id, root)
+	// TODO: https://github.com/dogmatiq/infix/issues/191
+	// There is currently no timeout on this context because the handler does
+	// not provide timeout hints. Aggregates should probably just use the
+	// default message timeout at all times.
+	rec, err := s.Cache.Acquire(ctx, id)
+	if err != nil {
+		return err
+	}
+	defer rec.Release()
+
+	inst, err := s.load(ctx, id, rec)
 	if err != nil {
 		return err
 	}
@@ -62,19 +82,55 @@ func (s *Sink) Accept(
 		handler: s.Identity,
 		logger:  s.Logger,
 		id:      id,
-		root:    root,
-		exists:  md.InstanceExists(),
+		root:    inst.root,
+		exists:  inst.metadata.InstanceExists(),
 	}
 
 	s.Handler.HandleCommand(sc, p.Message)
 
 	sc.validate()
 
-	if len(sc.events) > 0 {
-		return s.save(ctx, req, res, md, sc)
+	if err := s.save(
+		ctx,
+		req,
+		res,
+		inst.metadata,
+		sc,
+	); err != nil {
+		return err
 	}
 
+	rec.MarkInstanceSaved()
+
 	return nil
+}
+
+// load loads an aggregate instance, either from the given cache record, or
+// using the loader if the cache record is empty.
+func (s *Sink) load(
+	ctx context.Context,
+	id string,
+	rec *cache.Record,
+) (*instance, error) {
+	if rec.Instance != nil {
+		return rec.Instance.(*instance), nil
+	}
+
+	root := s.new()
+	md, err := s.Loader.Load(
+		ctx,
+		s.Identity.Key,
+		id,
+		root,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	inst := &instance{md, root}
+	rec.Instance = inst
+
+	return inst, nil
 }
 
 // save persists newly recorded events and updates the instance's meta-data.
@@ -85,6 +141,10 @@ func (s *Sink) save(
 	md *aggregatestore.MetaData,
 	sc *scope,
 ) error {
+	if len(sc.events) == 0 {
+		return nil
+	}
+
 	tx, err := req.Tx(ctx)
 	if err != nil {
 		return err

--- a/handler/aggregate/pipeline_test.go
+++ b/handler/aggregate/pipeline_test.go
@@ -291,15 +291,18 @@ var _ = Describe("type Sink", func() {
 						// Create() should now return true once again.
 						Expect(s.Create()).To(BeTrue())
 
-						// The root itself should also have been reset to as-new.
+						// The root itself should also have been reset to
+						// as-new. For our test root that means the internal
+						// slice of historical messages should be empty.
 						r := s.Root().(*AggregateRoot)
 						Expect(r.Value).To(Equal(
 							&[]dogma.Message{},
 						))
 
-						// We need to record an event whenever we create to
-						// prevent a panic, we do this after our assertion that
-						// the root is empty otherwise we this event applied.
+						// As per the Dogma API specification, we must record an
+						// event whenever we call Create(). This is done after
+						// the assertion that the root is empty otherwise we
+						// would see this event in the state.
 						s.RecordEvent(MessageE{Value: "<recreated>"})
 					}
 

--- a/handler/aggregate/pipeline_test.go
+++ b/handler/aggregate/pipeline_test.go
@@ -171,6 +171,42 @@ var _ = Describe("type Sink", func() {
 			}).To(PanicWith("the '<aggregate-name>' aggregate message handler returned a nil root from New()"))
 		})
 
+		It("returns an error if the deadline is exceeded while acquiring the cache record", func() {
+			blockReq, _ := NewPipelineRequestStub(
+				NewParcel("<blocking>", MessageC1),
+				dataStore,
+			)
+			blockRes := &pipeline.Response{}
+			defer blockReq.Close()
+
+			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
+
+			barrier := make(chan struct{})
+
+			handler.HandleCommandFunc = func(
+				dogma.AggregateCommandScope,
+				dogma.Message,
+			) {
+				close(barrier) // let the test proceed, we now hold the lock on the record
+				<-ctx.Done()   // don't unlock until the test assertions are complete
+			}
+
+			go sink.Accept(ctx, blockReq, blockRes)
+
+			select {
+			case <-barrier:
+			case <-ctx.Done():
+				Expect(ctx.Err()).ShouldNot(HaveOccurred())
+			}
+
+			ctx, cancel = context.WithTimeout(ctx, 20*time.Millisecond)
+			defer cancel()
+
+			err := sink.Accept(ctx, blockReq, blockRes)
+			Expect(err).To(Equal(context.DeadlineExceeded))
+		})
+
 		When("the instance does not exist", func() {
 			It("can be created", func() {
 				handler.HandleCommandFunc = func(

--- a/handler/aggregate/pipeline_test.go
+++ b/handler/aggregate/pipeline_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/dogmatiq/infix/draftspecs/envelopespec"
 	. "github.com/dogmatiq/infix/fixtures"
 	. "github.com/dogmatiq/infix/handler/aggregate"
+	"github.com/dogmatiq/infix/handler/cache"
 	"github.com/dogmatiq/infix/parcel"
 	"github.com/dogmatiq/infix/persistence"
 	"github.com/dogmatiq/infix/persistence/subsystem/aggregatestore"
@@ -84,6 +85,7 @@ var _ = Describe("type Sink", func() {
 				EventStore:     eventRepo,
 				Marshaler:      Marshaler,
 			},
+			Cache:  &cache.Cache{},
 			Packer: packer,
 			Logger: logger,
 		}

--- a/handler/cache/cache.go
+++ b/handler/cache/cache.go
@@ -42,7 +42,6 @@ func (c *Cache) Acquire(ctx context.Context, id string) (*Record, error) {
 		}
 
 		if rec.state != removed {
-			rec.state = active
 			return rec, nil
 		}
 

--- a/handler/cache/cache.go
+++ b/handler/cache/cache.go
@@ -42,7 +42,7 @@ func (c *Cache) Acquire(ctx context.Context, id string) (*Record, error) {
 		} else if logging.IsDebug(c.Logger) {
 			logging.Debug(
 				c.Logger,
-				"record added: %s (%p)",
+				"cache record added: %s (%p)",
 				id,
 				rec,
 			)

--- a/handler/cache/cache.go
+++ b/handler/cache/cache.go
@@ -1,0 +1,74 @@
+package cache
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/dogmatiq/linger"
+)
+
+// DefaultTTL is the default *minimum* period of time to keep cache records in
+// memory after they were last acquired.
+const DefaultTTL = 1 * time.Hour
+
+// Cache is an in-memory cache for storing aggregate and process instances for a
+// single handler.
+type Cache struct {
+	// TTL is the *minimum* period of time to keep cache records in memory after
+	// they were last used. If it is non-positive, DefaultTTL is used.
+	TTL time.Duration
+
+	records sync.Map
+}
+
+// Acquire locks and returns the cache record with the given ID.
+//
+// If the record has already been acquired, it blocks until the record is
+// released or ctx is canceled.
+func (c *Cache) Acquire(ctx context.Context, id string) (*Record, error) {
+	for {
+		rec := &Record{
+			id:    id,
+			cache: c,
+		}
+
+		if x, loaded := c.records.LoadOrStore(id, rec); loaded {
+			rec = x.(*Record)
+		}
+
+		if err := rec.m.Lock(ctx); err != nil {
+			return nil, err
+		}
+
+		if rec.state != removed {
+			rec.state = active
+			return rec, nil
+		}
+
+		// We finally got the lock, but this specific record has been removed
+		// from the cache, so we try again, creating a new record if necessary.
+		//
+		// We still need to unlock the mutex in case there are even more blocked
+		// acquirers for this record waiting to find out that they too failed
+		// miserably.
+		rec.m.Unlock()
+	}
+}
+
+// Run manages evicting idle records from the cache until ctx is canceled.
+func (c *Cache) Run(ctx context.Context) error {
+	for {
+		if err := linger.Sleep(ctx, c.TTL, DefaultTTL); err != nil {
+			return err
+		}
+
+		c.records.Range(
+			func(_, x interface{}) bool {
+				rec := x.(*Record)
+				rec.evict()
+				return true
+			},
+		)
+	}
+}

--- a/handler/cache/cache_test.go
+++ b/handler/cache/cache_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/dogmatiq/dodeca/logging"
 	"github.com/dogmatiq/infix/handler/cache"
 	. "github.com/dogmatiq/infix/handler/cache"
 	. "github.com/onsi/ginkgo"
@@ -20,7 +21,8 @@ var _ = Describe("type Cache", func() {
 	BeforeEach(func() {
 		ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
 		cache = &Cache{
-			TTL: 10 * time.Millisecond,
+			TTL:    10 * time.Millisecond,
+			Logger: logging.DebugLogger, // use a debug logger to ensure debug logging paths are covered
 		}
 	})
 

--- a/handler/cache/cache_test.go
+++ b/handler/cache/cache_test.go
@@ -21,7 +21,7 @@ var _ = Describe("type Cache", func() {
 	BeforeEach(func() {
 		ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
 		cache = &Cache{
-			TTL:    10 * time.Millisecond,
+			TTL:    20 * time.Millisecond,
 			Logger: logging.DebugLogger, // use a debug logger to ensure debug logging paths are covered
 		}
 	})
@@ -135,7 +135,7 @@ var _ = Describe("type Cache", func() {
 
 			By("running the eviction loop for longer than twice the TTL")
 
-			runCtx, cancelRun := context.WithTimeout(ctx, 25*time.Millisecond)
+			runCtx, cancelRun := context.WithTimeout(ctx, 3*cache.TTL)
 			defer cancelRun()
 			err = cache.Run(runCtx)
 			Expect(err).To(Equal(context.DeadlineExceeded))
@@ -161,7 +161,7 @@ var _ = Describe("type Cache", func() {
 			go func() {
 				defer GinkgoRecover()
 
-				time.Sleep(15 * time.Millisecond)
+				time.Sleep(cache.TTL + (cache.TTL / 2))
 
 				By("acquiring the record and calling KeepAlive() after the first eviction loop")
 
@@ -174,7 +174,7 @@ var _ = Describe("type Cache", func() {
 
 			By("running the eviction loop for longer than twice the TTL")
 
-			runCtx, cancelRun := context.WithTimeout(ctx, 25*time.Millisecond)
+			runCtx, cancelRun := context.WithTimeout(ctx, 3*cache.TTL)
 			defer cancelRun()
 			err = cache.Run(runCtx)
 			Expect(err).To(Equal(context.DeadlineExceeded))
@@ -197,7 +197,7 @@ var _ = Describe("type Cache", func() {
 
 			By("running the eviction loop for longer than twice the TTL")
 
-			runCtx, cancelRun := context.WithTimeout(ctx, 25*time.Millisecond)
+			runCtx, cancelRun := context.WithTimeout(ctx, 3*cache.TTL)
 			defer cancelRun()
 			err = cache.Run(runCtx)
 			Expect(err).To(Equal(context.DeadlineExceeded))

--- a/handler/cache/cache_test.go
+++ b/handler/cache/cache_test.go
@@ -1,0 +1,121 @@
+package cache_test
+
+import (
+	"context"
+	"time"
+
+	"github.com/dogmatiq/infix/handler/cache"
+	. "github.com/dogmatiq/infix/handler/cache"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("type Cache", func() {
+	var (
+		ctx    context.Context
+		cancel context.CancelFunc
+		cache  *cache.Cache
+	)
+
+	BeforeEach(func() {
+		ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
+		cache = &Cache{}
+	})
+
+	AfterEach(func() {
+		cancel()
+	})
+
+	Describe("func Acquire()", func() {
+		When("the instance has no record in the cache", func() {
+			It("returns a record with a nil instance", func() {
+				rec, err := cache.Acquire(ctx, "<id>")
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(rec).NotTo(BeNil())
+				defer rec.Release()
+
+				Expect(rec.Instance).To(BeNil())
+			})
+
+			It("adds the record to the cache", func() {
+				rec1, err := cache.Acquire(ctx, "<id>")
+				Expect(err).ShouldNot(HaveOccurred())
+				rec1.KeepAlive()
+				rec1.Release()
+
+				rec2, err := cache.Acquire(ctx, "<id>")
+				Expect(err).ShouldNot(HaveOccurred())
+				defer rec2.Release()
+
+				Expect(rec1).To(BeIdenticalTo(rec2))
+			})
+		})
+
+		When("the instance has a record in the cache", func() {
+			var record *Record
+
+			BeforeEach(func() {
+				var err error
+				record, err = cache.Acquire(ctx, "<id>")
+				Expect(err).ShouldNot(HaveOccurred())
+
+				record.Instance = "<instance value>"
+			})
+
+			When("the record is not locked", func() {
+				BeforeEach(func() {
+					record.KeepAlive()
+					record.Release()
+				})
+
+				It("returns the same instance on subsequent invocations", func() {
+					rec, err := cache.Acquire(ctx, "<id>")
+					Expect(err).ShouldNot(HaveOccurred())
+					defer rec.Release()
+
+					Expect(rec.Instance).To(Equal("<instance value>"))
+				})
+			})
+
+			When("the record is locked", func() {
+				It("blocks until the record is released", func() {
+					go func() {
+						time.Sleep(10 * time.Millisecond)
+						record.KeepAlive()
+						record.Release()
+					}()
+
+					rec, err := cache.Acquire(ctx, "<id>")
+					Expect(err).ShouldNot(HaveOccurred())
+					defer rec.Release()
+
+					Expect(rec.Instance).To(Equal("<instance value>"))
+				})
+
+				It("creates a new record if the locked record is not kept", func() {
+					go func() {
+						time.Sleep(10 * time.Millisecond)
+						record.Release()
+					}()
+
+					rec, err := cache.Acquire(ctx, "<id>")
+					Expect(err).ShouldNot(HaveOccurred())
+					defer rec.Release()
+
+					Expect(rec.Instance).To(BeNil())
+				})
+
+				It("returns an error if the deadline is exceeded", func() {
+					ctx, cancel := context.WithTimeout(ctx, 20*time.Millisecond)
+					defer cancel()
+
+					rec, err := cache.Acquire(ctx, "<id>")
+					if rec != nil {
+						rec.Release()
+					}
+					Expect(err).To(Equal(context.DeadlineExceeded))
+				})
+			})
+		})
+	})
+})

--- a/handler/cache/doc.go
+++ b/handler/cache/doc.go
@@ -1,0 +1,2 @@
+// Package cache provides an in-memory cache for aggregate and process instances.
+package cache

--- a/handler/cache/ginkgo_test.go
+++ b/handler/cache/ginkgo_test.go
@@ -1,0 +1,15 @@
+package cache_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
+)
+
+func TestSuite(t *testing.T) {
+	type tag struct{}
+	gomega.RegisterFailHandler(ginkgo.Fail)
+	ginkgo.RunSpecs(t, reflect.TypeOf(tag{}).PkgPath())
+}

--- a/handler/cache/record.go
+++ b/handler/cache/record.go
@@ -1,0 +1,72 @@
+package cache
+
+import "github.com/dogmatiq/infix/internal/x/syncx"
+
+// Record is an entry in the cache.
+type Record struct {
+	id    string
+	cache *Cache
+
+	m        syncx.Mutex
+	state    state
+	saved    bool
+	Instance interface{} // note: exposed, but still protected by m
+}
+
+// MarkInstanceSaved marks instance as it appears in the cache record as having
+// been successfully persisted.
+//
+// If this is NOT called, Release() assumes that modifications were made to
+// r.Instance that were not persisted successfully, and removes the record from
+// the cache.
+func (r *Record) MarkInstanceSaved() {
+	r.saved = true
+	r.cache.records.Delete(r.id)
+}
+
+// Release unlocks this record, allowing the key to be acquired by other
+// callers.
+func (r *Record) Release() {
+	if r.saved {
+		r.saved = false
+	} else {
+		r.remove()
+	}
+
+	r.m.Unlock()
+}
+
+// remove removes r from the cache.
+func (r *Record) remove() {
+	r.state = removed
+	r.cache.records.Delete(r.id)
+}
+
+// evict marks the record for eviction (idle), or actually evicts it if it's
+// already marked.
+func (r *Record) evict() {
+	if !r.m.TryLock() {
+		return
+	}
+	defer r.m.Unlock()
+
+	switch r.state {
+	case active:
+		// Mark the record as idle, if it's still idle on the next
+		// tick we'll remove it.
+		r.state = idle
+	case idle:
+		// It's still idle, meaning it hasn't been acquired since
+		// the last tick.
+		r.remove()
+	}
+}
+
+// state is an enumeration that describes the records state in the cache.
+type state int
+
+const (
+	active  state = iota // the record is in the cache, it may be locked or unlocked
+	idle                 // the record has been marked for eviction on the next cycle
+	removed              // the record has been removed from the cache, and is invalid
+)

--- a/handler/cache/record.go
+++ b/handler/cache/record.go
@@ -82,11 +82,21 @@ func (r *Record) evict() {
 	}
 }
 
-// state is an enumeration that describes the records state in the cache.
+// state is an enumeration that describes a record's state in the cache.
 type state int
 
 const (
-	active  state = iota // the record is in the cache, it may be locked or unlocked
-	idle                 // the record has been marked for eviction on the next cycle
-	removed              // the record has been removed from the cache, and is invalid
+	// active means that the record is still in the cache, and was created or
+	// KeepAlive() was called since the last eviction cycle.
+	active state = iota
+
+	// idle means that the record is in the cache, but KeepAlive() has not been
+	// called (and hence it has not been acquired) since the last eviction
+	// cycle. It will be evicted on the next cycle.
+	idle
+
+	// removed means that the record has been removed from the cache and should
+	// not be used. Locking the record's mutex does not guarantee exclusive
+	// access to the instance.
+	removed
 )

--- a/handler/cache/record.go
+++ b/handler/cache/record.go
@@ -1,6 +1,9 @@
 package cache
 
-import "github.com/dogmatiq/infix/internal/x/syncx"
+import (
+	"github.com/dogmatiq/dodeca/logging"
+	"github.com/dogmatiq/infix/internal/x/syncx"
+)
 
 // Record is an entry in the cache.
 type Record struct {
@@ -51,6 +54,15 @@ func (r *Record) Release() {
 		r.keep = false // for the next acquirer
 	} else {
 		r.remove()
+
+		if logging.IsDebug(r.cache.Logger) {
+			logging.Debug(
+				r.cache.Logger,
+				"record removed (released without keep-alive): %s (%p)",
+				r.id,
+				r,
+			)
+		}
 	}
 
 	r.m.Unlock()
@@ -75,10 +87,29 @@ func (r *Record) evict() {
 		// Mark the record as idle, if it's still idle on the next
 		// tick we'll remove it.
 		r.state = idle
+
+		if logging.IsDebug(r.cache.Logger) {
+			logging.Debug(
+				r.cache.Logger,
+				"record marked idle: %s (%p)",
+				r.id,
+				r,
+			)
+		}
+
 	case idle:
 		// It's still idle, meaning it hasn't been acquired since
 		// the last tick.
 		r.remove()
+
+		if logging.IsDebug(r.cache.Logger) {
+			logging.Debug(
+				r.cache.Logger,
+				"record removed (idle): %s (%p)",
+				r.id,
+				r,
+			)
+		}
 	}
 }
 

--- a/handler/cache/record.go
+++ b/handler/cache/record.go
@@ -21,13 +21,13 @@ type Record struct {
 // the cache.
 func (r *Record) MarkInstanceSaved() {
 	r.saved = true
-	r.cache.records.Delete(r.id)
 }
 
 // Release unlocks this record, allowing the key to be acquired by other
 // callers.
 func (r *Record) Release() {
 	if r.saved {
+		r.state = active
 		r.saved = false
 	} else {
 		r.remove()

--- a/handler/cache/record.go
+++ b/handler/cache/record.go
@@ -58,7 +58,7 @@ func (r *Record) Release() {
 		if logging.IsDebug(r.cache.Logger) {
 			logging.Debug(
 				r.cache.Logger,
-				"record removed (released without keep-alive): %s (%p)",
+				"cache record removed (released without keep-alive): %s (%p)",
 				r.id,
 				r,
 			)
@@ -91,7 +91,7 @@ func (r *Record) evict() {
 		if logging.IsDebug(r.cache.Logger) {
 			logging.Debug(
 				r.cache.Logger,
-				"record marked idle: %s (%p)",
+				"cache record marked idle: %s (%p)",
 				r.id,
 				r,
 			)
@@ -105,7 +105,7 @@ func (r *Record) evict() {
 		if logging.IsDebug(r.cache.Logger) {
 			logging.Debug(
 				r.cache.Logger,
-				"record removed (idle): %s (%p)",
+				"cache record removed (idle): %s (%p)",
 				r.id,
 				r,
 			)

--- a/handler/cache/record_test.go
+++ b/handler/cache/record_test.go
@@ -1,0 +1,63 @@
+package cache_test
+
+import (
+	"context"
+	"time"
+
+	"github.com/dogmatiq/infix/handler/cache"
+	. "github.com/dogmatiq/infix/handler/cache"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("type Cache", func() {
+	var (
+		ctx    context.Context
+		cancel context.CancelFunc
+		cache  *cache.Cache
+	)
+
+	BeforeEach(func() {
+		ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
+		cache = &Cache{}
+	})
+
+	AfterEach(func() {
+		cancel()
+	})
+
+	Describe("func Release()", func() {
+		var record *Record
+
+		BeforeEach(func() {
+			var err error
+			record, err = cache.Acquire(ctx, "<id>")
+			Expect(err).ShouldNot(HaveOccurred())
+
+			record.Instance = "<instance value>"
+		})
+
+		It("removes the record from the cache by default", func() {
+			record.Release()
+
+			rec, err := cache.Acquire(ctx, "<id>")
+			Expect(err).ShouldNot(HaveOccurred())
+			defer rec.Release()
+
+			// The instance will be nil again if the old record was not
+			// retained.
+			Expect(rec.Instance).To(BeNil())
+		})
+
+		It("keeps the record if KeepAlive() is called", func() {
+			record.KeepAlive()
+			record.Release()
+
+			rec, err := cache.Acquire(ctx, "<id>")
+			Expect(err).ShouldNot(HaveOccurred())
+			defer rec.Release()
+
+			Expect(rec.Instance).To(Equal("<instance value>"))
+		})
+	})
+})

--- a/handler/cache/record_test.go
+++ b/handler/cache/record_test.go
@@ -34,7 +34,7 @@ var _ = Describe("type Cache", func() {
 			record, err = cache.Acquire(ctx, "<id>")
 			Expect(err).ShouldNot(HaveOccurred())
 
-			record.Instance = "<instance value>"
+			record.Instance = "<value>"
 		})
 
 		It("removes the record from the cache by default", func() {
@@ -57,7 +57,7 @@ var _ = Describe("type Cache", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 			defer rec.Release()
 
-			Expect(rec.Instance).To(Equal("<instance value>"))
+			Expect(rec.Instance).To(Equal("<value>"))
 		})
 	})
 })

--- a/handler/cache/record_test.go
+++ b/handler/cache/record_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/dogmatiq/dodeca/logging"
 	"github.com/dogmatiq/infix/handler/cache"
 	. "github.com/dogmatiq/infix/handler/cache"
 	. "github.com/onsi/ginkgo"
@@ -19,7 +20,9 @@ var _ = Describe("type Cache", func() {
 
 	BeforeEach(func() {
 		ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
-		cache = &Cache{}
+		cache = &Cache{
+			Logger: logging.DebugLogger, // use a debug logger to ensure debug logging paths are covered
+		}
 	})
 
 	AfterEach(func() {

--- a/internal/x/syncx/mutex.go
+++ b/internal/x/syncx/mutex.go
@@ -5,6 +5,60 @@ import (
 	"sync"
 )
 
+// Mutex is a context-aware mutex.
+type Mutex struct {
+	once  sync.Once
+	guard chan struct{} // buffered guard, write = lock, read = unlock
+}
+
+// Lock acquires an exclusive lock on the mutex.
+//
+// It blocks until the mutex is acquired, or ctx is canceled.
+func (m *Mutex) Lock(ctx context.Context) error {
+	m.once.Do(func() {
+		m.guard = make(chan struct{}, 1)
+	})
+
+	select {
+	case m.guard <- struct{}{}: // lock the mutex
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// TryLock acquires an exclusive lock on the mutex if doing so would not block.
+//
+// It returns true if the mutex is locked.
+func (m *Mutex) TryLock() bool {
+	m.once.Do(func() {
+		m.guard = make(chan struct{}, 1)
+	})
+
+	select {
+	case m.guard <- struct{}{}: // lock the mutex
+		return true
+	default:
+		return false
+	}
+}
+
+// Unlock releases the mutex.
+//
+// It panics if the mutex is not currently locked.
+func (m *Mutex) Unlock() {
+	m.once.Do(func() {
+		m.guard = make(chan struct{}, 1)
+	})
+
+	select {
+	case <-m.guard: // unlock the mutex
+		return // keep to see coverage
+	default:
+		panic("mutex is not locked")
+	}
+}
+
 // RWMutex is a context-aware read/write mutex.
 type RWMutex struct {
 	m        sync.Mutex

--- a/internal/x/syncx/mutex_test.go
+++ b/internal/x/syncx/mutex_test.go
@@ -10,6 +10,104 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+var _ = Describe("type Mutex", func() {
+	var (
+		ctx    context.Context
+		cancel context.CancelFunc
+		mutex  *Mutex
+	)
+
+	BeforeEach(func() {
+		ctx, cancel = context.WithTimeout(context.Background(), 50*time.Millisecond)
+		mutex = &Mutex{}
+	})
+
+	AfterEach(func() {
+		cancel()
+	})
+
+	Describe("func Lock()", func() {
+		It("blocks calls to Lock()", func() {
+			err := mutex.Lock(ctx)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			err = mutex.Lock(ctx)
+			Expect(err).To(Equal(context.DeadlineExceeded))
+		})
+
+		It("causes TryLock() to return false", func() {
+			err := mutex.Lock(ctx)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			ok := mutex.TryLock()
+			Expect(ok).To(BeFalse())
+		})
+	})
+
+	Describe("func TryLock()", func() {
+		It("blocks calls to Lock()", func() {
+			ok := mutex.TryLock()
+			Expect(ok).To(BeTrue())
+
+			err := mutex.Lock(ctx)
+			Expect(err).To(Equal(context.DeadlineExceeded))
+		})
+
+		It("causes TryLock() to return false", func() {
+			ok := mutex.TryLock()
+			Expect(ok).To(BeTrue())
+
+			ok = mutex.TryLock()
+			Expect(ok).To(BeFalse())
+		})
+	})
+
+	Describe("func Unlock()", func() {
+		It("allows subsequent calls to Lock()", func() {
+			err := mutex.Lock(ctx)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			mutex.Unlock()
+
+			err = mutex.Lock(ctx)
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+
+		It("allows subsequent calls to TryLock()", func() {
+			err := mutex.Lock(ctx)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			mutex.Unlock()
+
+			ok := mutex.TryLock()
+			Expect(ok).To(BeTrue())
+		})
+
+		It("unblocks one blocking call to Lock()", func() {
+			err := mutex.Lock(ctx)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			errors := make(chan error, 2)
+			fn := func() { errors <- mutex.Lock(ctx) }
+
+			go fn()
+			go fn()
+
+			time.Sleep(5 * time.Millisecond)
+			mutex.Unlock()
+
+			Expect(<-errors).ShouldNot(HaveOccurred())
+			Expect(<-errors).To(Equal(context.DeadlineExceeded))
+		})
+
+		It("panics if the mutex is not locked", func() {
+			Expect(func() {
+				mutex.Unlock()
+			}).To(Panic())
+		})
+	})
+})
+
 var _ = Describe("type RWMutex", func() {
 	var (
 		ctx    context.Context


### PR DESCRIPTION
Fixes #185

This PR introduces a highly-use-case-specific cache to the `aggregate.Sink`. Each handler has its own cache instance, and each record in the cache represents an aggregate instance.

Records are "acquired" from the cache, locking them so that no other goroutine can acquire them at the same time. This ensures that only one goroutine handles a message for a given instance at a time, reducing the likelihood of OCC failures without any IO. (This approach made #187 redundant, which is why I closed it).

When a cache record has been acquired, the acquirer must explicitly call a `KeepAlive()` method in order to retain that record in the cache when it's released. This approach feels a little unusual to me, but seems to work well in practice because it automatically invalidates the cache record whenever there is a failure condition, which for aggregates includes several very intentional `panic()`.  

Some other notes:

- I used `sync.Map`. I will need to benchmark to know that this is the right choice, but the intent is definitely that the cache should remain quite stable which suits `sync.Map` performance profile. This could definitely change to `map` + `mutex` with little issue.

- I tried to keep manipulations of the underlying map to a minimum. This is another request I chose the acquire/release approach, rather than get/set like you might normally have in a cache. When a record is manipulated and marked with `KeepAlive()` the same record simply stays in the map, there is no update of the map at all in the happy-path.