### PR TITLE
Correctly increment offset in persistencedstream.

### DIFF
--- a/eventstream/networkstream/server.go
+++ b/eventstream/networkstream/server.go
@@ -171,6 +171,7 @@ func (s *server) Consume(
 				return err
 			}
 
+			req.Offset++
 		}
 
 		// TODO: https://github.com/dogmatiq/infix/issues/74

--- a/eventstream/persistedstream/stream.go
+++ b/eventstream/persistedstream/stream.go
@@ -200,7 +200,7 @@ func (c *cursor) execQuery(ctx context.Context) error {
 
 		select {
 		case c.events <- ev:
-			continue
+			c.query.MinOffset++
 		case <-ctx.Done():
 			return ctx.Err()
 		}


### PR DESCRIPTION
This PR fixes an issue shared by both `persistencestream.Stream` and `networkstream.server` whereby the `MinOffset` used to query the event store was not being incremented after reading an event, resulting in repeatedly returning the same event from the cursor after reaching the end of the persisted events the first time.

This initially went unnoticed because the only place the stream was used was to populate projections, which would immediately retry by opening the cursor at the next offset. An error was logged but the projection content was correct.

Fixes #194