### PR TITLE
Add a timeout to aggregate cache acquire/load operation.

### DIFF
--- a/app.go
+++ b/app.go
@@ -210,7 +210,8 @@ func (f *routeFactory) VisitRichAggregate(_ context.Context, cfg configkit.RichA
 			Produced:    cfg.MessageTypes().Produced,
 			Consumed:    cfg.MessageTypes().Consumed,
 		},
-		Logger: f.appLogger,
+		LoadTimeout: f.opts.MessageTimeout,
+		Logger:      f.appLogger,
 	}
 
 	for mt := range cfg.MessageTypes().Consumed {

--- a/handler/aggregate/pipeline_test.go
+++ b/handler/aggregate/pipeline_test.go
@@ -95,9 +95,10 @@ var _ = Describe("type Sink", func() {
 				EventStore:     eventRepo,
 				Marshaler:      Marshaler,
 			},
-			Cache:  &cache.Cache{},
-			Packer: packer,
-			Logger: logger,
+			Cache:       &cache.Cache{},
+			Packer:      packer,
+			LoadTimeout: 1 * time.Second,
+			Logger:      logger,
 		}
 	})
 

--- a/handler/integration/pipeline.go
+++ b/handler/integration/pipeline.go
@@ -66,14 +66,7 @@ func (s *Sink) Accept(
 		logger:  s.Logger,
 	}
 
-	hctx, cancel := linger.ContextWithTimeout(
-		ctx,
-		s.Handler.TimeoutHint(p.Message),
-		s.DefaultTimeout,
-	)
-	defer cancel()
-
-	if err := s.Handler.HandleCommand(hctx, sc, p.Message); err != nil {
+	if err := s.handle(ctx, sc, p.Message); err != nil {
 		return err
 	}
 
@@ -89,4 +82,16 @@ func (s *Sink) Accept(
 	}
 
 	return nil
+}
+
+// handle invokes the handler with a timeout based on its timeout hint.
+func (s *Sink) handle(ctx context.Context, sc *scope, m dogma.Message) error {
+	ctx, cancel := linger.ContextWithTimeout(
+		ctx,
+		s.Handler.TimeoutHint(m),
+		s.DefaultTimeout,
+	)
+	defer cancel()
+
+	return s.Handler.HandleCommand(ctx, sc, m)
 }


### PR DESCRIPTION
Fixes #191 

Note that aggregate handlers themselves don't accept a context because they are pure functions. 

This timeout applies to the `cache.Acquire()` and `loader.Load()` operations.