### PR TITLE
Ensure stream events are not duplicated when the first offset is filtered out.

### DIFF
--- a/eventstream/persistedstream/stream.go
+++ b/eventstream/persistedstream/stream.go
@@ -200,7 +200,7 @@ func (c *cursor) execQuery(ctx context.Context) error {
 
 		select {
 		case c.events <- ev:
-			c.query.MinOffset++
+			c.query.MinOffset = i.Offset + 1
 		case <-ctx.Done():
 			return ctx.Err()
 		}


### PR DESCRIPTION
Fixes #194.

This PR corrects PR #197 which provided a insufficent fix to #194.