### PR TITLE
Add method for getting the next free offset from the event store.

### DIFF
--- a/persistence/internal/providertest/eventstore/repository.go
+++ b/persistence/internal/providertest/eventstore/repository.go
@@ -81,6 +81,14 @@ func DeclareRepositoryTests(tc *common.TestContext) {
 			tearDown()
 		})
 
+		ginkgo.Describe("func NextEventOffset()", func() {
+			ginkgo.It("returns zero if the store is empty", func() {
+				o, err := repository.NextEventOffset(ctx)
+				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+				gomega.Expect(o).To(gomega.BeEquivalentTo(0))
+			})
+		})
+
 		ginkgo.Describe("func QueryEvents()", func() {
 			ginkgo.It("returns an empty result if the store is empty", func() {
 				items := queryEvents(tc.Context, repository, eventstore.Query{})

--- a/persistence/internal/providertest/eventstore/repository.go
+++ b/persistence/internal/providertest/eventstore/repository.go
@@ -83,7 +83,7 @@ func DeclareRepositoryTests(tc *common.TestContext) {
 
 		ginkgo.Describe("func NextEventOffset()", func() {
 			ginkgo.It("returns zero if the store is empty", func() {
-				o, err := repository.NextEventOffset(ctx)
+				o, err := repository.NextEventOffset(tc.Context)
 				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 				gomega.Expect(o).To(gomega.BeEquivalentTo(0))
 			})

--- a/persistence/internal/providertest/eventstore/repository.go
+++ b/persistence/internal/providertest/eventstore/repository.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 
 	dogmafixtures "github.com/dogmatiq/dogma/fixtures"
+	"github.com/dogmatiq/infix/draftspecs/envelopespec"
 	infixfixtures "github.com/dogmatiq/infix/fixtures"
 	"github.com/dogmatiq/infix/persistence"
 	"github.com/dogmatiq/infix/persistence/internal/providertest/common"
@@ -86,6 +87,34 @@ func DeclareRepositoryTests(tc *common.TestContext) {
 				o, err := repository.NextEventOffset(tc.Context)
 				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 				gomega.Expect(o).To(gomega.BeEquivalentTo(0))
+			})
+
+			ginkgo.It("returns the offset after the last recorded event", func() {
+				var g sync.WaitGroup
+
+				fn := func(env *envelopespec.Envelope) {
+					defer ginkgo.GinkgoRecover()
+					defer g.Done()
+					saveEvents(tc.Context, dataStore, env)
+				}
+
+				g.Add(3)
+				go fn(item0.Envelope)
+				go fn(item1.Envelope)
+				go fn(item2.Envelope)
+				g.Wait()
+
+				o, err := repository.NextEventOffset(tc.Context)
+				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+				gomega.Expect(o).To(gomega.BeEquivalentTo(3))
+			})
+
+			ginkgo.It("returns an error if the context is canceled", func() {
+				ctx, cancel := context.WithCancel(tc.Context)
+				cancel()
+
+				_, err := repository.NextEventOffset(ctx)
+				gomega.Expect(err).To(gomega.Equal(context.Canceled))
 			})
 		})
 

--- a/persistence/provider/memory/eventstore.go
+++ b/persistence/provider/memory/eventstore.go
@@ -28,6 +28,20 @@ type eventStoreRepository struct {
 	db *database
 }
 
+// NextEventOffset returns the next "unused" offset within the store.
+func (r *eventStoreRepository) NextEventOffset(
+	ctx context.Context,
+) (eventstore.Offset, error) {
+	if err := r.db.RLock(ctx); err != nil {
+		return 0, err
+	}
+
+	next := eventstore.Offset(len(r.db.event.items))
+	r.db.RUnlock()
+
+	return next, nil
+}
+
 // QueryEvents queries events in the repository.
 func (r *eventStoreRepository) QueryEvents(
 	ctx context.Context,

--- a/persistence/provider/sql/eventstore.go
+++ b/persistence/provider/sql/eventstore.go
@@ -56,6 +56,14 @@ type eventStoreDriver interface {
 		ak string,
 	) error
 
+	// SelectNextEventOffset selects the next "unused" offset from the
+	// eventstore.
+	SelectNextEventOffset(
+		ctx context.Context,
+		db *sql.DB,
+		ak string,
+	) (eventstore.Offset, error)
+
 	// SelectEvents selects events from the eventstore that match the given
 	// query.
 	//
@@ -112,6 +120,17 @@ type eventStoreRepository struct {
 	db     *sql.DB
 	driver Driver
 	appKey string
+}
+
+// NextEventOffset returns the next "unused" offset within the store.
+func (r *eventStoreRepository) NextEventOffset(
+	ctx context.Context,
+) (eventstore.Offset, error) {
+	return r.driver.SelectNextEventOffset(
+		ctx,
+		r.db,
+		r.appKey,
+	)
 }
 
 // QueryEvents queries events in the repository.

--- a/persistence/provider/sql/mysql/eventstore.go
+++ b/persistence/provider/sql/mysql/eventstore.go
@@ -155,6 +155,29 @@ func (driver) PurgeEventFilters(
 	return err
 }
 
+// SelectNextEventOffset selects the next "unused" offset from the event store.
+func (driver) SelectNextEventOffset(
+	ctx context.Context,
+	db *sql.DB,
+	ak string,
+) (eventstore.Offset, error) {
+	row := db.QueryRowContext(
+		ctx,
+		`SELECT
+			next_offset
+		FROM event_offset`,
+	)
+
+	var next eventstore.Offset
+
+	err := row.Scan(&next)
+	if err == sql.ErrNoRows {
+		err = nil
+	}
+
+	return next, err
+}
+
 // SelectEvents selects events from the eventstore that match the given query.
 //
 // f is a filter ID, as returned by InsertEventFilter(). If the query does not

--- a/persistence/provider/sql/postgres/error.go
+++ b/persistence/provider/sql/postgres/error.go
@@ -152,6 +152,15 @@ func (d errorConverter) PurgeEventFilters(
 	return convertContextErrors(ctx, err)
 }
 
+func (d errorConverter) SelectNextEventOffset(
+	ctx context.Context,
+	db *sql.DB,
+	ak string,
+) (eventstore.Offset, error) {
+	next, err := d.d.SelectNextEventOffset(ctx, db, ak)
+	return next, convertContextErrors(ctx, err)
+}
+
 func (d errorConverter) SelectEvents(
 	ctx context.Context,
 	db *sql.DB,

--- a/persistence/provider/sql/postgres/eventstore.go
+++ b/persistence/provider/sql/postgres/eventstore.go
@@ -157,6 +157,29 @@ func (driver) PurgeEventFilters(
 	return err
 }
 
+// SelectNextEventOffset selects the next "unused" offset from the event store.
+func (driver) SelectNextEventOffset(
+	ctx context.Context,
+	db *sql.DB,
+	ak string,
+) (eventstore.Offset, error) {
+	row := db.QueryRowContext(
+		ctx,
+		`SELECT
+			next_offset
+		FROM infix.event_offset`,
+	)
+
+	var next eventstore.Offset
+
+	err := row.Scan(&next)
+	if err == sql.ErrNoRows {
+		err = nil
+	}
+
+	return next, err
+}
+
 // SelectEvents selects events from the eventstore that match the given query.
 //
 // f is a filter ID, as returned by InsertEventFilter(). If the query does not

--- a/persistence/provider/sql/sqlite/eventstore.go
+++ b/persistence/provider/sql/sqlite/eventstore.go
@@ -198,6 +198,29 @@ func (driver) PurgeEventFilters(
 	return tx.Commit()
 }
 
+// SelectNextEventOffset selects the next "unused" offset from the event store.
+func (driver) SelectNextEventOffset(
+	ctx context.Context,
+	db *sql.DB,
+	ak string,
+) (eventstore.Offset, error) {
+	row := db.QueryRowContext(
+		ctx,
+		`SELECT
+			next_offset
+		FROM event_offset`,
+	)
+
+	var next eventstore.Offset
+
+	err := row.Scan(&next)
+	if err == sql.ErrNoRows {
+		err = nil
+	}
+
+	return next, err
+}
+
 // SelectEvents selects events from the eventstore that match the given query.
 //
 // f is a filter ID, as returned by InsertEventFilter(). If the query does not

--- a/persistence/subsystem/eventstore/repository.go
+++ b/persistence/subsystem/eventstore/repository.go
@@ -6,6 +6,9 @@ import (
 
 // Repository is an interface for reading persisted event messages.
 type Repository interface {
+	// NextEventOffset returns the next "unused" offset within the store.
+	NextEventOffset(ctx context.Context) (Offset, error)
+
 	// QueryEvents queries events in the repository.
 	QueryEvents(ctx context.Context, q Query) (Result, error)
 }


### PR DESCRIPTION
This PR adds the `eventstore.Repository.NextEventOffset()` method, which returns the next "unused" offset in the store.

One use for this will be used when one application discovers another and wants to start consuming events that "happen from  now on", rather than from offset `0`, which will be the case for processes. 

This probably wouldn't have been done until the 0.2.0 "multiple apps" milestone, except that it will also be useful for #74 to prime the buffer with recent events even after a cold start.

It's naturally racy, insofar as the store could have an event persisted to it the moment you get the result, but that is adequate for these use cases.
