### PR TITLE
Remove `EnqueuedCommand` and `RecordedEvent`.

### DIFF
--- a/pipeline/observe.go
+++ b/pipeline/observe.go
@@ -2,10 +2,18 @@ package pipeline
 
 import (
 	"context"
+
+	"github.com/dogmatiq/infix/parcel"
+	"github.com/dogmatiq/infix/persistence/subsystem/eventstore"
+	"github.com/dogmatiq/infix/persistence/subsystem/queuestore"
 )
 
 // QueueObserver is a function that is notified when messages are enqueued.
-type QueueObserver func(context.Context, []EnqueuedMessage) error
+type QueueObserver func(
+	context.Context,
+	[]*parcel.Parcel,
+	[]*queuestore.Item,
+) error
 
 // WhenMessageEnqueued returns a pipeline stage that calls fn when messages
 // are enqueued by any subsequent pipeline stage, and that stage is successful.
@@ -15,27 +23,31 @@ func WhenMessageEnqueued(fn QueueObserver) Stage {
 			return err
 		}
 
-		if len(res.EnqueuedMessages) > 0 {
-			return fn(ctx, res.EnqueuedMessages)
+		if len(res.queueParcels) > 0 {
+			return fn(ctx, res.queueParcels, res.queueItems)
 		}
 
 		return nil
 	}
 }
 
-// EventStreamObserver is a function that is notified when events are recorded.
-type EventStreamObserver func(context.Context, []RecordedEvent) error
+// EventObserver is a function that is notified when events are recorded.
+type EventObserver func(
+	context.Context,
+	[]*parcel.Parcel,
+	[]*eventstore.Item,
+) error
 
 // WhenEventRecorded returns a pipeline stage that calls fn when events are
 // recorded by any subsequent pipeline stage, and that state is successful.
-func WhenEventRecorded(fn EventStreamObserver) Stage {
+func WhenEventRecorded(fn EventObserver) Stage {
 	return func(ctx context.Context, req Request, res *Response, next Sink) error {
 		if err := next(ctx, req, res); err != nil {
 			return err
 		}
 
-		if len(res.RecordedEvents) > 0 {
-			return fn(ctx, res.RecordedEvents)
+		if len(res.eventParcels) > 0 {
+			return fn(ctx, res.eventParcels, res.eventItems)
 		}
 
 		return nil

--- a/pipeline/observe_test.go
+++ b/pipeline/observe_test.go
@@ -43,19 +43,21 @@ var _ = Context("observer stages", func() {
 
 			fn := func(
 				ctx context.Context,
-				messages []EnqueuedMessage,
+				parcels []*parcel.Parcel,
+				items []*queuestore.Item,
 			) error {
 				called = true
 
-				Expect(messages).To(EqualX(
-					[]EnqueuedMessage{
+				Expect(parcels).To(EqualX(
+					[]*parcel.Parcel{pcl},
+				))
+
+				Expect(items).To(EqualX(
+					[]*queuestore.Item{
 						{
-							Parcel: pcl,
-							Persisted: &queuestore.Item{
-								Revision:      1,
-								NextAttemptAt: now,
-								Envelope:      pcl.Envelope,
-							},
+							Revision:      1,
+							NextAttemptAt: now,
+							Envelope:      pcl.Envelope,
 						},
 					},
 				))
@@ -76,7 +78,8 @@ var _ = Context("observer stages", func() {
 		It("does not call the observer function if no messages were enqueued", func() {
 			fn := func(
 				context.Context,
-				[]EnqueuedMessage,
+				[]*parcel.Parcel,
+				[]*queuestore.Item,
 			) error {
 				Fail("unexpected call")
 				return nil
@@ -91,7 +94,8 @@ var _ = Context("observer stages", func() {
 		It("does not call the observer function if the next stage fails", func() {
 			fn := func(
 				context.Context,
-				[]EnqueuedMessage,
+				[]*parcel.Parcel,
+				[]*queuestore.Item,
 			) error {
 				Fail("unexpected call")
 				return nil
@@ -113,7 +117,8 @@ var _ = Context("observer stages", func() {
 		It("returns an error if an observer function fails", func() {
 			fn := func(
 				context.Context,
-				[]EnqueuedMessage,
+				[]*parcel.Parcel,
+				[]*queuestore.Item,
 			) error {
 				return errors.New("<error>")
 			}
@@ -134,18 +139,20 @@ var _ = Context("observer stages", func() {
 
 			fn := func(
 				ctx context.Context,
-				messages []RecordedEvent,
+				parcels []*parcel.Parcel,
+				items []*eventstore.Item,
 			) error {
 				called = true
 
-				Expect(messages).To(EqualX(
-					[]RecordedEvent{
+				Expect(parcels).To(EqualX(
+					[]*parcel.Parcel{pcl},
+				))
+
+				Expect(items).To(EqualX(
+					[]*eventstore.Item{
 						{
-							Parcel: pcl,
-							Persisted: &eventstore.Item{
-								Offset:   0,
-								Envelope: pcl.Envelope,
-							},
+							Offset:   0,
+							Envelope: pcl.Envelope,
 						},
 					},
 				))
@@ -167,7 +174,8 @@ var _ = Context("observer stages", func() {
 		It("does not call the observer function if no messages were enqueued", func() {
 			fn := func(
 				context.Context,
-				[]RecordedEvent,
+				[]*parcel.Parcel,
+				[]*eventstore.Item,
 			) error {
 				Fail("unexpected call")
 				return nil
@@ -182,7 +190,8 @@ var _ = Context("observer stages", func() {
 		It("does not call the observer function if the next stage fails", func() {
 			fn := func(
 				context.Context,
-				[]RecordedEvent,
+				[]*parcel.Parcel,
+				[]*eventstore.Item,
 			) error {
 				Fail("unexpected call")
 				return nil
@@ -204,7 +213,8 @@ var _ = Context("observer stages", func() {
 		It("returns an error if an observer function fails", func() {
 			fn := func(
 				context.Context,
-				[]RecordedEvent,
+				[]*parcel.Parcel,
+				[]*eventstore.Item,
 			) error {
 				return errors.New("<error>")
 			}

--- a/pipeline/queue/pipeline.go
+++ b/pipeline/queue/pipeline.go
@@ -3,6 +3,8 @@ package queue
 import (
 	"context"
 
+	"github.com/dogmatiq/infix/parcel"
+	"github.com/dogmatiq/infix/persistence/subsystem/queuestore"
 	"github.com/dogmatiq/infix/pipeline"
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/sync/semaphore"
@@ -62,9 +64,13 @@ func (s *PipelineSource) Run(ctx context.Context) error {
 // TrackEnqueuedCommands returns a pipeline observer that calls q.Track() for
 // each message that is enqueued.
 func TrackEnqueuedCommands(q *Queue) pipeline.QueueObserver {
-	return func(ctx context.Context, messages []pipeline.EnqueuedMessage) error {
-		for _, m := range messages {
-			if err := q.Track(ctx, m.Parcel, m.Persisted); err != nil {
+	return func(
+		ctx context.Context,
+		parcels []*parcel.Parcel,
+		items []*queuestore.Item,
+	) error {
+		for i, p := range parcels {
+			if err := q.Track(ctx, p, items[i]); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
This PR removes these two container types, as they had a tendency to cause coupling to the `pipeline` package when there really needn't be any.

These types contained a `*parcel.Parcel` and the `*[queue|event]store.Item`. Instead I've changed the pipeline observers to pass two separate slices of parcels and items to the observers.

This not only removes this extra type and hence the coupling, but also means that observers that don't care about one of the representations (parcel, or item) don't have to iterate through to extract the value they do care about from the container type.