### PR TITLE
Implement `eventbuffer.Buffer`.

### DIFF
--- a/eventstream/eventbuffer/buffer.go
+++ b/eventstream/eventbuffer/buffer.go
@@ -1,0 +1,258 @@
+package eventbuffer
+
+import (
+	"context"
+	"errors"
+	"sync"
+
+	"github.com/dogmatiq/dodeca/logging"
+	"github.com/dogmatiq/infix/internal/x/containerx/pqueue"
+	"github.com/dogmatiq/infix/parcel"
+	"github.com/dogmatiq/infix/persistence/subsystem/eventstore"
+)
+
+// DefaultSize is the default number of recent events to buffer in memory.
+const DefaultSize = 100
+
+// Buffer is an in-memory buffer of recently recorded events.
+type Buffer struct {
+	// NextOffset is the offset of the next event to be recorded. This value is
+	// not updated as time goes on, it is simply used to "seed" the buffer with
+	// this information.
+	NextOffset eventstore.Offset
+
+	// Size is the maximum number of messages to buffer in memory.
+	// If it is non-positive, DefaultSize is used.
+	Size int
+
+	// Logger is the target for log messages from the buffer.
+	// If it is nil, logging.DefaultLogger is used.
+	Logger logging.Logger
+
+	once    sync.Once
+	m       sync.RWMutex
+	reorder pqueue.Queue      // buffer of slices that arrived out-of-order
+	ring    []*parcel.Parcel  // ring-buffer of recent history
+	cursor  int               // index into ring where the next event is inserted
+	begin   eventstore.Offset // lowest offset in the ring, inclusive
+	end     eventstore.Offset // highest offset in the ring, exclusive, aka "next"
+	next    *future           // fulfilled when the parcel at "end" is added
+}
+
+type elem struct {
+	begin   eventstore.Offset
+	parcels []*parcel.Parcel
+}
+
+func (e *elem) Less(v pqueue.Elem) bool {
+	return e.begin < v.(*elem).begin
+}
+
+// Get returns a parcel containing the event at a specific offset.
+//
+// If the event at the given offset is in the buffer ok is true and p is the
+// event's parcel.
+//
+// If o is later than the latest offset known to the buffer, Get() blocks until
+// the event with that offset is added to the buffer, or ctx is canceled.
+//
+// If o is earlier than the earliest offset in the buffer ok is false and p is
+// nil. The caller must load the event directly from the event store.
+func (b *Buffer) Get(
+	ctx context.Context,
+	o eventstore.Offset,
+) (p *parcel.Parcel, ok bool, err error) {
+	b.init()
+
+	b.m.RLock()
+	p, next, err := b.get(o)
+	b.m.RUnlock()
+
+	if next != nil {
+		p, err = next.await(ctx)
+	}
+
+	return p, p != nil, err
+}
+
+func (b *Buffer) get(o eventstore.Offset) (*parcel.Parcel, *future, error) {
+	if o == b.end {
+		// The requested offset is the next offset we expect to be recorded.
+		// This should be the common case as consumers catch up to the end of
+		// the stream.
+		return nil, b.next, nil
+	}
+
+	if o < b.begin {
+		// The requested offset is old enough that it's no longer in the buffer,
+		// the consumer should load the event from the store.
+		return nil, nil, nil
+	}
+
+	if o > b.end {
+		// The requested offset is after next offset we expect to be recorded -
+		// how did a consumer come to expect this event without having seen the
+		// "next" one?
+		return nil, nil, errors.New("requested offset is in the future")
+	}
+
+	index := b.cursor - int(b.end-o)
+	if index < 0 {
+		index += len(b.ring)
+	}
+
+	return b.ring[index], nil, nil
+}
+
+// Add adds events to the buffer.
+//
+// Note: The buffer takes ownership of the parcels slice.
+func (b *Buffer) Add(begin eventstore.Offset, parcels []*parcel.Parcel) {
+	b.init()
+
+	b.m.Lock()
+	defer b.m.Unlock()
+
+	if begin > b.end {
+		logging.Debug(
+			b.Logger,
+			"deferring %d out-of-order event(s) beginning at offset %d (begin: %d, end: %d)",
+			len(parcels),
+			begin,
+			b.begin,
+			b.end,
+		)
+
+		b.reorder.Push(&elem{
+			begin:   begin,
+			parcels: parcels,
+		})
+
+		return
+	}
+
+	if begin < b.end {
+		logging.Debug(
+			b.Logger,
+			"discarding %d old event(s) beginning at offset %d (begin: %d, end: %d)",
+			len(parcels),
+			begin,
+			b.begin,
+			b.end,
+		)
+
+		return
+	}
+
+	logging.Debug(
+		b.Logger,
+		"adding %d event(s) and waking any blocked consumers (begin: %d, end: %d)",
+		len(parcels),
+		b.begin,
+		b.end,
+	)
+
+	b.next.resolve(parcels[0])
+	b.next = &future{}
+
+	ok := true
+	for ok {
+		b.addBatch(parcels)
+		parcels, ok = b.nextBatch()
+	}
+}
+
+func (b *Buffer) addBatch(parcels []*parcel.Parcel) {
+	var (
+		capacity = len(b.ring)
+		count    = len(parcels)
+	)
+
+	b.end += eventstore.Offset(count)
+
+	if n := count - capacity; n >= 0 {
+		// For whatever strange reason the buffer is configured with a buffer
+		// size so small that we've got enough events in this single batch to
+		// fill the entire ring. We just replace the ring wholesale with the
+		// tail of the batch.
+		b.ring = parcels[n:]
+		b.cursor = 0
+		b.begin = b.end - eventstore.Offset(capacity)
+
+		logging.Debug(
+			b.Logger,
+			"replaced entire buffer with %d event(s) from the batch (begin: %d, end: %d)",
+			capacity,
+			b.begin,
+			b.end,
+		)
+
+		return
+	}
+
+	if n := int(b.end-b.begin) - capacity; n > 0 {
+		// The buffer would become too big after these events are added, which
+		// means they will "wrap" around the ring and overwrite our oldest
+		// events. We have to adjust b.begin to match.
+		b.begin += eventstore.Offset(n)
+
+		logging.Debug(
+			b.Logger,
+			"dropped %d old event(s) from the buffer (begin: %d, end: %d)",
+			n,
+			b.begin,
+			b.end,
+		)
+	}
+
+	// Copy the parcels into the ring buffer. First the start of the batch over
+	// the second half of the ring, then we copy the remainder over the first
+	// half of the ring.
+	copy(b.ring[b.cursor:], parcels)
+	if n := capacity - b.cursor; count > n {
+		copy(b.ring, parcels[n:])
+	}
+
+	// Finally, we adjust the cursor to the be the index where the next parcel
+	// will be inserted, wrapping back to zero if it exceeds the end of the ring.
+	b.cursor += count
+	if b.cursor >= capacity {
+		b.cursor -= capacity
+	}
+}
+
+// nextBatch pops the next batch from the reorder queue if it's become the
+// "next" expected set of events.
+func (b *Buffer) nextBatch() ([]*parcel.Parcel, bool) {
+	if e, ok := b.reorder.Peek(); ok {
+		e := e.(*elem)
+		if e.begin == b.end {
+			logging.Debug(
+				b.Logger,
+				"adding %d event(s) from out-of-order batch (begin: %d, end: %d)",
+				len(e.parcels),
+				b.begin,
+				b.end,
+			)
+
+			b.reorder.Pop()
+			return e.parcels, true
+		}
+	}
+
+	return nil, false
+}
+
+func (b *Buffer) init() {
+	b.once.Do(func() {
+		size := b.Size
+		if size <= 0 {
+			size = DefaultSize
+		}
+
+		b.ring = make([]*parcel.Parcel, size)
+		b.begin = b.NextOffset
+		b.end = b.NextOffset
+		b.next = &future{}
+	})
+}

--- a/eventstream/eventbuffer/buffer_test.go
+++ b/eventstream/eventbuffer/buffer_test.go
@@ -1,0 +1,242 @@
+package eventbuffer_test
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/dogmatiq/dodeca/logging"
+	. "github.com/dogmatiq/dogma/fixtures"
+	. "github.com/dogmatiq/infix/eventstream/eventbuffer"
+	. "github.com/dogmatiq/infix/fixtures"
+	"github.com/dogmatiq/infix/parcel"
+	"github.com/dogmatiq/infix/persistence/subsystem/eventstore"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("type EventBuffer", func() {
+	var (
+		ctx    context.Context
+		cancel context.CancelFunc
+		buffer *Buffer
+	)
+
+	BeforeEach(func() {
+		ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
+
+		buffer = &Buffer{
+			// For the purposes of our test, we assume there are already 100
+			// events in the store.
+			NextOffset: 100,
+			Logger:     logging.DebugLogger,
+		}
+	})
+
+	AfterEach(func() {
+		cancel()
+	})
+
+	Describe("func Add()", func() {
+		When("the events are the next expected events", func() {
+			It("adds the events to the buffer immediately", func() {
+				addEvents(ctx, buffer, 100, 101)
+
+				expectEventToBeBuffered(buffer, 100)
+				expectEventToBeBuffered(buffer, 101)
+			})
+		})
+
+		When("the events are not the next expected events", func() {
+			It("add the events to the buffer once the 'missing' events are added", func() {
+				addEvents(ctx, buffer, 102, 103)
+				addEvents(ctx, buffer, 104, 105)
+				addEvents(ctx, buffer, 100, 101)
+
+				expectEventToBeBuffered(buffer, 100)
+				expectEventToBeBuffered(buffer, 101)
+				expectEventToBeBuffered(buffer, 102)
+				expectEventToBeBuffered(buffer, 103)
+				expectEventToBeBuffered(buffer, 104)
+				expectEventToBeBuffered(buffer, 105)
+			})
+		})
+
+		When("the events are older than the oldest events already in the buffer", func() {
+			It("discards the events", func() {
+				addEvents(ctx, buffer, 100, 101)
+				addEvents(ctx, buffer, 98, 99)
+
+				expectEventNotToBeBuffered(buffer, 98)
+				expectEventNotToBeBuffered(buffer, 99)
+			})
+		})
+
+		It("drops the oldest events when the buffer capacity is reached", func() {
+			buffer.Size = 3
+
+			addEvents(ctx, buffer, 100, 101)
+			addEvents(ctx, buffer, 102, 103)
+
+			expectEventNotToBeBuffered(buffer, 100)
+			expectEventToBeBuffered(buffer, 101)
+			expectEventToBeBuffered(buffer, 102)
+			expectEventToBeBuffered(buffer, 103)
+		})
+
+		It("drops the oldest events when a single call fills the entire buffer", func() {
+			buffer.Size = 3
+
+			addEvents(ctx, buffer, 100, 103)
+
+			expectEventNotToBeBuffered(buffer, 100)
+			expectEventToBeBuffered(buffer, 101)
+			expectEventToBeBuffered(buffer, 102)
+			expectEventToBeBuffered(buffer, 103)
+		})
+	})
+
+	Describe("func Get()", func() {
+		When("the buffer is empty", func() {
+			When("the requested offset is before the next expected offset", func() {
+				It("returns false", func() {
+					_, ok, err := buffer.Get(ctx, 99)
+					Expect(err).ShouldNot(HaveOccurred())
+					Expect(ok).To(BeFalse())
+				})
+			})
+		})
+
+		When("the buffer is not empty", func() {
+			BeforeEach(func() {
+				addEvents(ctx, buffer, 100, 102)
+			})
+
+			When("the requested offset is before the oldest event in the buffer", func() {
+				It("returns false", func() {
+					_, ok, err := buffer.Get(ctx, 99)
+					Expect(err).ShouldNot(HaveOccurred())
+					Expect(ok).To(BeFalse())
+				})
+			})
+
+			When("the requested offset is before the next expected offset", func() {
+				It("returns the parcel from the buffer", func() {
+					p, ok, err := buffer.Get(ctx, 101)
+					Expect(err).ShouldNot(HaveOccurred())
+					Expect(ok).To(BeTrue())
+					Expect(p.Message).To(Equal(
+						MessageE{Value: "<event-101>"},
+					))
+				})
+			})
+		})
+
+		When("the requested offset is equal to the next offset", func() {
+			It("blocks until the next event is added", func() {
+				go func() {
+					defer GinkgoRecover()
+
+					time.Sleep(10 * time.Millisecond)
+
+					// Add out-of-order to ensure Get() doesn't unblock on
+					// the "future" events.
+					addEvents(ctx, buffer, 103, 104)
+					addEvents(ctx, buffer, 100, 102)
+				}()
+
+				p, ok, err := buffer.Get(ctx, 100)
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(ok).To(BeTrue())
+				Expect(p.Message).To(Equal(
+					MessageE{Value: "<event-100>"},
+				))
+			})
+
+			It("returns an error if the deadline is exceeded", func() {
+				ctx, cancel := context.WithTimeout(ctx, 20*time.Millisecond)
+				defer cancel()
+
+				_, _, err := buffer.Get(ctx, 100)
+				Expect(err).To(Equal(context.DeadlineExceeded))
+			})
+		})
+
+		When("the requested offset is after the next expected offset", func() {
+			It("returns an error", func() {
+				_, _, err := buffer.Get(ctx, 101)
+				Expect(err).To(MatchError("requested offset is in the future"))
+			})
+		})
+	})
+})
+
+// addEvents adds events in the range [begin, end] in a single call to
+// b.Add().
+func addEvents(
+	ctx context.Context,
+	b *Buffer,
+	begin, end eventstore.Offset,
+) {
+	var parcels []*parcel.Parcel
+
+	for o := begin; o <= end; o++ {
+		id := fmt.Sprintf("<event-%d>", o)
+		parcels = append(
+			parcels,
+			NewParcel(
+				id,
+				MessageE{
+					Value: id,
+				},
+			),
+		)
+	}
+
+	b.Add(begin, parcels)
+}
+
+// expectEventToBeBuffered asserts that the event with the given offset is in
+// the buffer.
+func expectEventToBeBuffered(
+	b *Buffer,
+	o eventstore.Offset,
+) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
+
+	p, ok, err := b.Get(ctx, o)
+	Expect(err).ShouldNot(HaveOccurred())
+
+	Expect(ok).To(
+		BeTrue(),
+		fmt.Sprintf("expected event at offset %d to be in the buffer", o),
+	)
+
+	Expect(p.Message).To(Equal(
+		MessageE{
+			Value: fmt.Sprintf("<event-%d>", o),
+		},
+	))
+}
+
+// expectEventNotToBeBuffered asserts that the event with the given offset is
+// not in the buffer.
+func expectEventNotToBeBuffered(
+	b *Buffer,
+	o eventstore.Offset,
+) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
+
+	_, ok, err := b.Get(ctx, o)
+
+	Expect(ok).To(
+		BeFalse(),
+		fmt.Sprintf("did not expect event at offset %d to be in the buffer", o),
+	)
+
+	if err != nil {
+		Expect(err).To(Equal(context.Canceled))
+	}
+}

--- a/eventstream/eventbuffer/doc.go
+++ b/eventstream/eventbuffer/doc.go
@@ -1,0 +1,3 @@
+// Package eventbuffer is an in-memory representation of the most recent events
+// from the event store.
+package eventbuffer

--- a/eventstream/eventbuffer/future.go
+++ b/eventstream/eventbuffer/future.go
@@ -1,0 +1,68 @@
+package eventbuffer
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+
+	"github.com/dogmatiq/infix/parcel"
+)
+
+type future struct {
+	done     uint32     // atomic bool, fast path, protects parcel field
+	m        sync.Mutex // slow path, protects parcel and resolved channel
+	parcel   *parcel.Parcel
+	resolved chan struct{}
+}
+
+// await blocks until the future is resolved, then returns the parcel it was
+// resolved with.
+func (f *future) await(ctx context.Context) (*parcel.Parcel, error) {
+	if atomic.LoadUint32(&f.done) == 1 {
+		// The "fast path" was successful, we know there's a parcel, no need to
+		// read from the resolved channel.
+		return f.parcel, nil
+	}
+
+	// Otherwise, we take the "slow path" of locking the mutex.
+	f.m.Lock()
+
+	if f.parcel != nil {
+		// The future was resolved while we were waiting for the mutex, still
+		// want to avoid the channel if possible, so return immediately.
+		f.m.Unlock()
+		return f.parcel, nil
+	}
+
+	if f.resolved == nil {
+		// We're the first caller to await, so we need to initialize the
+		// channel.
+		f.resolved = make(chan struct{})
+	}
+
+	f.m.Unlock()
+
+	// At this point we know that f.resolved will never be written again, and
+	// that f.parcel will never be written after f.resolved is closed, so
+	// there's no more mutexes to worry about.
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-f.resolved:
+		return f.parcel, nil
+	}
+}
+
+// resolve wakes any blocked calls to Await() and causes them to return p.
+func (f *future) resolve(p *parcel.Parcel) {
+	f.m.Lock()
+
+	f.parcel = p
+	atomic.StoreUint32(&f.done, 1)
+
+	if f.resolved != nil {
+		close(f.resolved)
+	}
+
+	f.m.Unlock()
+}

--- a/eventstream/eventbuffer/ginkgo_test.go
+++ b/eventstream/eventbuffer/ginkgo_test.go
@@ -1,0 +1,15 @@
+package eventbuffer_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
+)
+
+func TestSuite(t *testing.T) {
+	type tag struct{}
+	gomega.RegisterFailHandler(ginkgo.Fail)
+	ginkgo.RunSpecs(t, reflect.TypeOf(tag{}).PkgPath())
+}


### PR DESCRIPTION
Partially addresses #74 

This PR implements the "eventbuffer.Buffer" type, which is an in-memory buffer of the most recent events from a (local) application's event store that serves as a coordination point for multiple consumers waiting for new events to occur. 

It's analogous to `queue.Queue` which services a similar role for the message queue. However, whereas the `queue.Queue` type will eventually end up with the entire queue in memory as it shrinks, the `eventbuffer.Buffer` will only keep up to a fixed number of events as the store grows. I am open to better names than buffer!

Events are added to the buffer in contiguous batches, which is how they "emerge" from the pipeline observer after being committed in a transaction. However, the batches themselves can be out of order as each transaction is handled in a separate goroutine. To solve this the implementation uses a priority queue onto which it places batches of events that arrive out of order. In practice I would hope this "reordering" queue would remain very small, but I would ideally like to refactor to exclude this queue altogether.

The events from "recent history", once they have been reordered are stored in a fixed-size ring buffer implemented atop `[]*parcel.Parcel`.

Finally there is the `future` type which represents the "yet-to-arrive-ever-elusive-very-next-event".  Whenever a consumer requests an event at the next offset that is expected to occur, it waits upon this `future` which is fulfilled when that next event is added to the buffer.  The name `future` is taken by analogy to similar generic types in C# and C++, from memory, but it's not a concept we tend to see in Go.