### PR TITLE
Use memory stream as a cache of recent events.

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -115,7 +115,7 @@ func (e *Engine) run(ctx context.Context) error {
 		})
 
 		g.Go(func() error {
-			return e.runStreamConsumersForEachApp(ctx, a.Stream)
+			return e.runStreamConsumersForEachApp(ctx, a.EventStream)
 		})
 	}
 

--- a/eventstream/persistedstream/cursor.go
+++ b/eventstream/persistedstream/cursor.go
@@ -81,12 +81,12 @@ func (c *cursor) consume(ctx context.Context) {
 	defer close(c.events)
 
 	for {
-		if err := c.consumeFromStore(ctx); err != nil {
+		if err := c.consumeFromCache(ctx); err != nil {
 			c.close(err)
 			return
 		}
 
-		if err := c.consumeFromCache(ctx); err != nil {
+		if err := c.consumeFromStore(ctx); err != nil {
 			c.close(err)
 			return
 		}

--- a/eventstream/persistedstream/stream.go
+++ b/eventstream/persistedstream/stream.go
@@ -25,6 +25,12 @@ type Stream struct {
 	// Marshaler is used to unmarshal messages.
 	Marshaler marshalkit.Marshaler
 
+	// Cache is an in-memory stream that contains recently recorded events.
+	//
+	// The cache must be provided, otherwise the stream has no way to block
+	// until a new event is recorded.
+	Cache eventstream.Stream
+
 	// PreFetch specifies how many messages to pre-load into memory.
 	PreFetch int
 }
@@ -83,6 +89,8 @@ func (s *Stream) Open(
 		repository: s.Repository,
 		query:      q,
 		marshaler:  s.Marshaler,
+		cache:      s.Cache,
+		filter:     f,
 		cancel:     cancelConsume,
 		events:     make(chan *eventstream.Event, s.PreFetch),
 	}

--- a/network.go
+++ b/network.go
@@ -67,7 +67,7 @@ func (e *Engine) registerEventStreamServer(ctx context.Context, s *grpc.Server) 
 			options,
 			networkstream.WithApplication(
 				k,
-				a.Stream,
+				a.EventStream,
 				a.Config.
 					MessageTypes().
 					Produced.

--- a/pipeline/eventstream.go
+++ b/pipeline/eventstream.go
@@ -1,0 +1,32 @@
+package pipeline
+
+import (
+	"context"
+
+	"github.com/dogmatiq/infix/eventstream"
+	"github.com/dogmatiq/infix/eventstream/memorystream"
+	"github.com/dogmatiq/infix/parcel"
+	"github.com/dogmatiq/infix/persistence/subsystem/eventstore"
+)
+
+// AddToEventCache returns an observer that calls c.Add() for each batch of
+// events that is recorded.
+func AddToEventCache(c *memorystream.Stream) EventObserver {
+	return func(
+		_ context.Context,
+		parcels []*parcel.Parcel,
+		items []*eventstore.Item,
+	) error {
+		events := make([]*eventstream.Event, len(parcels))
+
+		for i, p := range parcels {
+			events[i] = &eventstream.Event{
+				Offset: items[i].Offset,
+				Parcel: p,
+			}
+		}
+
+		c.Add(events)
+		return nil
+	}
+}

--- a/pipeline/eventstream_test.go
+++ b/pipeline/eventstream_test.go
@@ -1,0 +1,77 @@
+package pipeline_test
+
+import (
+	"context"
+	"time"
+
+	"github.com/dogmatiq/configkit"
+	"github.com/dogmatiq/configkit/message"
+	. "github.com/dogmatiq/dogma/fixtures"
+	"github.com/dogmatiq/infix/eventstream"
+	"github.com/dogmatiq/infix/eventstream/memorystream"
+	. "github.com/dogmatiq/infix/fixtures"
+	"github.com/dogmatiq/infix/parcel"
+	"github.com/dogmatiq/infix/persistence/subsystem/eventstore"
+	"github.com/dogmatiq/infix/pipeline"
+	. "github.com/dogmatiq/infix/pipeline"
+	. "github.com/jmalloc/gomegax"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("func AddToEventCache()", func() {
+	var (
+		ctx      context.Context
+		cancel   context.CancelFunc
+		stream   *memorystream.Stream
+		observer pipeline.EventObserver
+		pcl      *parcel.Parcel
+		item     *eventstore.Item
+	)
+
+	BeforeEach(func() {
+		ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
+
+		pcl = NewParcel("<id>", MessageA1)
+
+		stream = &memorystream.Stream{
+			App:         configkit.MustNewIdentity("<app-key>", "<app-name>"),
+			Types:       message.TypesOf(MessageA{}),
+			FirstOffset: 123,
+		}
+
+		observer = AddToEventCache(stream)
+
+		item = &eventstore.Item{
+			Offset:   123,
+			Envelope: pcl.Envelope,
+		}
+	})
+
+	AfterEach(func() {
+		cancel()
+	})
+
+	It("caches events when they are recorded", func() {
+		err := observer(
+			ctx,
+			[]*parcel.Parcel{pcl},
+			[]*eventstore.Item{item},
+		)
+		Expect(err).ShouldNot(HaveOccurred())
+
+		cur, err := stream.Open(ctx, 123, stream.Types)
+		Expect(err).ShouldNot(HaveOccurred())
+		defer cur.Close()
+
+		ev, err := cur.Next(ctx)
+		Expect(err).ShouldNot(HaveOccurred())
+
+		Expect(ev).To(EqualX(
+			&eventstream.Event{
+				Offset: 123,
+				Parcel: pcl,
+			},
+		))
+	})
+})

--- a/pipeline/queue.go
+++ b/pipeline/queue.go
@@ -61,8 +61,8 @@ func (s *QueueSource) Run(ctx context.Context) error {
 	return g.Wait()
 }
 
-// TrackWithQueue returns a pipeline observer that calls q.Track() for
-// each message that is enqueued.
+// TrackWithQueue returns an observer that calls q.Track() for each message that
+// is enqueued.
 func TrackWithQueue(q *queue.Queue) QueueObserver {
 	return func(
 		ctx context.Context,


### PR DESCRIPTION
Blocked by #217, fixes #74

This PR changes `persistedstream.Stream` to use a `memorystream.Stream` as a cache of recent events.

`persistedstream.cursor` now hits this cache first, falling back to query an `eventstore.Repository` if the required offset is too old to be in the cache.  

Once the cursor "runs out" of events in the store, in other words, it has caught up to the tail of the stream, it tries to "lock onto" the memory stream again, using it exclusively from then on.
