### PR TITLE
Remove custom integer types for offsets and revisions.

### DIFF
--- a/eventstream/consumer.go
+++ b/eventstream/consumer.go
@@ -17,13 +17,13 @@ type Handler interface {
 	// specific application's event stream.
 	//
 	// id is the identity of the source application.
-	NextOffset(ctx context.Context, id configkit.Identity) (Offset, error)
+	NextOffset(ctx context.Context, id configkit.Identity) (uint64, error)
 
 	// HandleEvent handles an event obtained from the event stream.
 	//
 	// o must be the offset that would be returned by NextOffset(). On success,
 	// the next call to NextOffset() will return ev.Offset + 1.
-	HandleEvent(ctx context.Context, o Offset, ev *Event) error
+	HandleEvent(ctx context.Context, o uint64, ev *Event) error
 }
 
 // Consumer reads events from a stream in order to handle them.
@@ -49,7 +49,7 @@ type Consumer struct {
 	// If it is nil, logging.DefaultLogger is used.
 	Logger logging.Logger
 
-	offset        Offset
+	offset        uint64
 	backoff       backoff.Counter
 	handlerFailed bool
 }

--- a/eventstream/consumer_test.go
+++ b/eventstream/consumer_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/dogmatiq/configkit/message"
 	"github.com/dogmatiq/dodeca/logging"
 	. "github.com/dogmatiq/dogma/fixtures"
-	"github.com/dogmatiq/infix/eventstream"
 	. "github.com/dogmatiq/infix/eventstream"
 	"github.com/dogmatiq/infix/eventstream/memorystream"
 	. "github.com/dogmatiq/infix/fixtures"
@@ -109,7 +108,7 @@ var _ = Describe("type Consumer", func() {
 			var events []*Event
 			eshandler.HandleEventFunc = func(
 				_ context.Context,
-				_ eventstream.Offset,
+				_ uint64,
 				ev *Event,
 			) error {
 				events = append(events, ev)
@@ -146,14 +145,14 @@ var _ = Describe("type Consumer", func() {
 		It("restarts the consumer if opening the stream returns an error", func() {
 			stream.OpenFunc = func(
 				context.Context,
-				eventstream.Offset,
+				uint64,
 				message.TypeCollection,
 			) (Cursor, error) {
 				stream.OpenFunc = nil
 
 				eshandler.HandleEventFunc = func(
 					_ context.Context,
-					_ eventstream.Offset,
+					_ uint64,
 					ev *Event,
 				) error {
 					Expect(ev).To(Equal(event0))
@@ -176,7 +175,7 @@ var _ = Describe("type Consumer", func() {
 
 				eshandler.HandleEventFunc = func(
 					_ context.Context,
-					_ eventstream.Offset,
+					_ uint64,
 					ev *Event,
 				) error {
 					Expect(ev).To(Equal(event0))
@@ -194,12 +193,12 @@ var _ = Describe("type Consumer", func() {
 		It("restarts the consumer when the handler returns an error", func() {
 			eshandler.HandleEventFunc = func(
 				context.Context,
-				eventstream.Offset,
+				uint64,
 				*Event,
 			) error {
 				eshandler.HandleEventFunc = func(
 					_ context.Context,
-					_ eventstream.Offset,
+					_ uint64,
 					ev *Event,
 				) error {
 					Expect(ev).To(Equal(event0))
@@ -224,7 +223,7 @@ var _ = Describe("type Consumer", func() {
 			eshandler.NextOffsetFunc = func(
 				context.Context,
 				configkit.Identity,
-			) (eventstream.Offset, error) {
+			) (uint64, error) {
 				return 0, errors.New("<error>")
 			}
 
@@ -258,7 +257,7 @@ var _ = Describe("type Consumer", func() {
 				eshandler.NextOffsetFunc = func(
 					_ context.Context,
 					id configkit.Identity,
-				) (eventstream.Offset, error) {
+				) (uint64, error) {
 					Expect(id).To(Equal(
 						configkit.MustNewIdentity("<app-name>", "<app-key>"),
 					))
@@ -267,7 +266,7 @@ var _ = Describe("type Consumer", func() {
 
 				eshandler.HandleEventFunc = func(
 					_ context.Context,
-					_ eventstream.Offset,
+					_ uint64,
 					ev *Event,
 				) error {
 					Expect(ev).To(Equal(event2))
@@ -283,13 +282,13 @@ var _ = Describe("type Consumer", func() {
 				eshandler.NextOffsetFunc = func(
 					context.Context,
 					configkit.Identity,
-				) (eventstream.Offset, error) {
+				) (uint64, error) {
 					return 2, nil
 				}
 
 				eshandler.HandleEventFunc = func(
 					_ context.Context,
-					o eventstream.Offset,
+					o uint64,
 					_ *Event,
 				) error {
 					Expect(o).To(BeNumerically("==", 2))
@@ -304,19 +303,19 @@ var _ = Describe("type Consumer", func() {
 			It("restarts the consumer when a conflict occurs", func() {
 				eshandler.HandleEventFunc = func(
 					context.Context,
-					eventstream.Offset,
+					uint64,
 					*Event,
 				) error {
 					eshandler.NextOffsetFunc = func(
 						context.Context,
 						configkit.Identity,
-					) (eventstream.Offset, error) {
+					) (uint64, error) {
 						return 2, nil
 					}
 
 					eshandler.HandleEventFunc = func(
 						_ context.Context,
-						_ eventstream.Offset,
+						_ uint64,
 						ev *Event,
 					) error {
 						Expect(ev).To(Equal(event2))
@@ -335,14 +334,14 @@ var _ = Describe("type Consumer", func() {
 				eshandler.NextOffsetFunc = func(
 					context.Context,
 					configkit.Identity,
-				) (eventstream.Offset, error) {
+				) (uint64, error) {
 					eshandler.NextOffsetFunc = nil
 					return 0, errors.New("<error>")
 				}
 
 				eshandler.HandleEventFunc = func(
 					_ context.Context,
-					_ eventstream.Offset,
+					_ uint64,
 					ev *Event,
 				) error {
 					Expect(ev).To(Equal(event0))

--- a/eventstream/event.go
+++ b/eventstream/event.go
@@ -2,13 +2,10 @@ package eventstream
 
 import "github.com/dogmatiq/infix/parcel"
 
-// Offset is the 0-based index of an event on a stream.
-type Offset uint64
-
 // Event is a container for an envelope and event stream specific meta-data.
 type Event struct {
-	// Offset is the offset of the message on the stream.
-	Offset Offset
+	// Offset is the 0-based index of the event on the stream.
+	Offset uint64
 
 	// Parcel contains the event from the stream.
 	Parcel *parcel.Parcel

--- a/eventstream/memorystream/cursor.go
+++ b/eventstream/memorystream/cursor.go
@@ -11,7 +11,7 @@ import (
 // cursor is a Cursor that reads events from an in-memory stream.
 type cursor struct {
 	stream *Stream
-	offset eventstream.Offset
+	offset uint64
 	filter message.TypeCollection
 
 	once   sync.Once
@@ -73,7 +73,7 @@ func (c *cursor) get() (*eventstream.Event, <-chan struct{}) {
 	c.stream.m.Lock()
 	defer c.stream.m.Unlock()
 
-	for eventstream.Offset(len(c.stream.events)) > c.offset {
+	for uint64(len(c.stream.events)) > c.offset {
 		offset := c.offset
 		c.offset++
 

--- a/eventstream/memorystream/stream.go
+++ b/eventstream/memorystream/stream.go
@@ -45,7 +45,7 @@ func (s *Stream) EventTypes(context.Context) (message.TypeCollection, error) {
 // indicated by EventTypes().
 func (s *Stream) Open(
 	ctx context.Context,
-	o eventstream.Offset,
+	o uint64,
 	f message.TypeCollection,
 ) (eventstream.Cursor, error) {
 	if f.Len() == 0 {
@@ -69,7 +69,7 @@ func (s *Stream) Append(parcels ...*parcel.Parcel) {
 	s.m.Lock()
 	defer s.m.Unlock()
 
-	o := eventstream.Offset(len(s.events))
+	o := uint64(len(s.events))
 
 	for _, p := range parcels {
 		t := message.TypeOf(p.Message)

--- a/eventstream/networkstream/cursor.go
+++ b/eventstream/networkstream/cursor.go
@@ -94,7 +94,7 @@ func (c *cursor) recv() error {
 	}
 
 	ev := &eventstream.Event{
-		Offset: eventstream.Offset(res.Offset),
+		Offset: res.Offset,
 	}
 
 	ev.Parcel, err = parcel.FromEnvelope(c.marshaler, res.GetEnvelope())

--- a/eventstream/networkstream/server.go
+++ b/eventstream/networkstream/server.go
@@ -217,7 +217,7 @@ func (s *server) query(req *messagingspec.ConsumeRequest) (eventstore.Query, err
 	}
 
 	return eventstore.Query{
-		MinOffset: eventstore.Offset(req.GetOffset()),
+		MinOffset: req.GetOffset(),
 		Filter:    eventstore.NewFilter(types...),
 	}, nil
 }

--- a/eventstream/networkstream/server.go
+++ b/eventstream/networkstream/server.go
@@ -165,7 +165,7 @@ func (s *server) Consume(
 			}
 
 			res := &messagingspec.ConsumeResponse{
-				Offset:   uint64(i.Offset),
+				Offset:   i.Offset,
 				Envelope: i.Envelope,
 			}
 

--- a/eventstream/networkstream/stream.go
+++ b/eventstream/networkstream/stream.go
@@ -67,7 +67,7 @@ func (s *Stream) EventTypes(ctx context.Context) (message.TypeCollection, error)
 // indicated by EventTypes().
 func (s *Stream) Open(
 	ctx context.Context,
-	o eventstream.Offset,
+	o uint64,
 	f message.TypeCollection,
 ) (eventstream.Cursor, error) {
 	if f.Len() == 0 {
@@ -98,7 +98,7 @@ func (s *Stream) Open(
 
 	req := &messagingspec.ConsumeRequest{
 		ApplicationKey: s.App.Key,
-		Offset:         uint64(o),
+		Offset:         o,
 		Types:          marshalMessageTypes(s.Marshaler, f),
 	}
 

--- a/eventstream/persistedstream/cursor.go
+++ b/eventstream/persistedstream/cursor.go
@@ -106,7 +106,7 @@ func (c *cursor) execQuery(ctx context.Context) error {
 		}
 
 		ev := &eventstream.Event{
-			Offset: eventstream.Offset(i.Offset),
+			Offset: i.Offset,
 		}
 
 		ev.Parcel, err = parcel.FromEnvelope(c.marshaler, i.Envelope)

--- a/eventstream/persistedstream/stream.go
+++ b/eventstream/persistedstream/stream.go
@@ -63,7 +63,7 @@ func (s *Stream) Open(
 	}
 
 	q := eventstore.Query{
-		MinOffset: eventstore.Offset(o),
+		MinOffset: o,
 	}
 
 	f.Range(func(mt message.Type) bool {

--- a/eventstream/persistedstream/stream.go
+++ b/eventstream/persistedstream/stream.go
@@ -51,7 +51,7 @@ func (s *Stream) EventTypes(context.Context) (message.TypeCollection, error) {
 // indicated by EventTypes().
 func (s *Stream) Open(
 	ctx context.Context,
-	o eventstream.Offset,
+	o uint64,
 	f message.TypeCollection,
 ) (eventstream.Cursor, error) {
 	if f.Len() == 0 {

--- a/eventstream/stream.go
+++ b/eventstream/stream.go
@@ -26,7 +26,7 @@ type Stream interface {
 	//
 	// It returns an error if any of the event types in f are not supported, as
 	// indicated by EventTypes().
-	Open(ctx context.Context, o Offset, f message.TypeCollection) (Cursor, error)
+	Open(ctx context.Context, o uint64, f message.TypeCollection) (Cursor, error)
 }
 
 // ErrCursorClosed is returned by Cursor.Next() and Close() if the

--- a/fixtures/eventstream.go
+++ b/fixtures/eventstream.go
@@ -14,7 +14,7 @@ type EventStreamStub struct {
 
 	ApplicationFunc func() configkit.Identity
 	EventTypesFunc  func(context.Context) (message.TypeCollection, error)
-	OpenFunc        func(context.Context, eventstream.Offset, message.TypeCollection) (eventstream.Cursor, error)
+	OpenFunc        func(context.Context, uint64, message.TypeCollection) (eventstream.Cursor, error)
 }
 
 // Application returns the identity of the application that owns the stream.
@@ -46,7 +46,7 @@ func (s *EventStreamStub) EventTypes(ctx context.Context) (message.TypeCollectio
 // Open returns a cursor that reads events from the stream.
 func (s *EventStreamStub) Open(
 	ctx context.Context,
-	offset eventstream.Offset,
+	offset uint64,
 	types message.TypeCollection,
 ) (eventstream.Cursor, error) {
 	if s.OpenFunc != nil {
@@ -65,8 +65,8 @@ func (s *EventStreamStub) Open(
 type EventStreamHandlerStub struct {
 	eventstream.Handler
 
-	NextOffsetFunc  func(context.Context, configkit.Identity) (eventstream.Offset, error)
-	HandleEventFunc func(context.Context, eventstream.Offset, *eventstream.Event) error
+	NextOffsetFunc  func(context.Context, configkit.Identity) (uint64, error)
+	HandleEventFunc func(context.Context, uint64, *eventstream.Event) error
 }
 
 // NextOffset returns the offset of the next event to be consumed from a
@@ -74,7 +74,7 @@ type EventStreamHandlerStub struct {
 func (h *EventStreamHandlerStub) NextOffset(
 	ctx context.Context,
 	id configkit.Identity,
-) (eventstream.Offset, error) {
+) (uint64, error) {
 	if h.NextOffsetFunc != nil {
 		return h.NextOffsetFunc(ctx, id)
 	}
@@ -89,7 +89,7 @@ func (h *EventStreamHandlerStub) NextOffset(
 // HandleEvent handles an event obtained from the event stream.
 func (h *EventStreamHandlerStub) HandleEvent(
 	ctx context.Context,
-	o eventstream.Offset,
+	o uint64,
 	ev *eventstream.Event,
 ) error {
 	if h.HandleEventFunc != nil {

--- a/fixtures/offsetstore.go
+++ b/fixtures/offsetstore.go
@@ -3,7 +3,6 @@ package fixtures
 import (
 	"context"
 
-	"github.com/dogmatiq/infix/eventstream"
 	"github.com/dogmatiq/infix/persistence/subsystem/offsetstore"
 )
 
@@ -12,14 +11,14 @@ import (
 type OffsetStoreRepositoryStub struct {
 	offsetstore.Repository
 
-	LoadOffsetFunc func(ctx context.Context, ak string) (eventstream.Offset, error)
+	LoadOffsetFunc func(ctx context.Context, ak string) (uint64, error)
 }
 
 // LoadOffset loads the offset associated with a specific application.
 func (r *OffsetStoreRepositoryStub) LoadOffset(
 	ctx context.Context,
 	ak string,
-) (eventstream.Offset, error) {
+) (uint64, error) {
 	if r.LoadOffsetFunc != nil {
 		return r.LoadOffsetFunc(ctx, ak)
 	}

--- a/fixtures/persistence.go
+++ b/fixtures/persistence.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/dogmatiq/infix/draftspecs/envelopespec"
-	"github.com/dogmatiq/infix/eventstream"
 	"github.com/dogmatiq/infix/persistence"
 	"github.com/dogmatiq/infix/persistence/provider/memory"
 	"github.com/dogmatiq/infix/persistence/subsystem/aggregatestore"
@@ -180,7 +179,7 @@ type TransactionStub struct {
 
 	SaveAggregateMetaDataFunc  func(context.Context, *aggregatestore.MetaData) error
 	SaveEventFunc              func(context.Context, *envelopespec.Envelope) (eventstore.Offset, error)
-	SaveOffsetFunc             func(ctx context.Context, ak string, c, n eventstream.Offset) error
+	SaveOffsetFunc             func(ctx context.Context, ak string, c, n uint64) error
 	SaveMessageToQueueFunc     func(context.Context, *queuestore.Item) error
 	RemoveMessageFromQueueFunc func(context.Context, *queuestore.Item) error
 
@@ -219,7 +218,7 @@ func (t *TransactionStub) SaveEvent(ctx context.Context, env *envelopespec.Envel
 func (t *TransactionStub) SaveOffset(
 	ctx context.Context,
 	ak string,
-	c, n eventstream.Offset,
+	c, n uint64,
 ) error {
 	if t.SaveOffsetFunc != nil {
 		return t.SaveOffsetFunc(ctx, ak, c, n)

--- a/fixtures/persistence.go
+++ b/fixtures/persistence.go
@@ -178,7 +178,7 @@ type TransactionStub struct {
 	persistence.Transaction
 
 	SaveAggregateMetaDataFunc  func(context.Context, *aggregatestore.MetaData) error
-	SaveEventFunc              func(context.Context, *envelopespec.Envelope) (eventstore.Offset, error)
+	SaveEventFunc              func(context.Context, *envelopespec.Envelope) (uint64, error)
 	SaveOffsetFunc             func(ctx context.Context, ak string, c, n uint64) error
 	SaveMessageToQueueFunc     func(context.Context, *queuestore.Item) error
 	RemoveMessageFromQueueFunc func(context.Context, *queuestore.Item) error
@@ -201,7 +201,7 @@ func (t *TransactionStub) SaveAggregateMetaData(ctx context.Context, md *aggrega
 }
 
 // SaveEvent persists an event in the application's event store.
-func (t *TransactionStub) SaveEvent(ctx context.Context, env *envelopespec.Envelope) (eventstore.Offset, error) {
+func (t *TransactionStub) SaveEvent(ctx context.Context, env *envelopespec.Envelope) (uint64, error) {
 	if t.SaveEventFunc != nil {
 		return t.SaveEventFunc(ctx, env)
 	}

--- a/handler/aggregate/pipeline.go
+++ b/handler/aggregate/pipeline.go
@@ -13,7 +13,6 @@ import (
 	"github.com/dogmatiq/infix/internal/mlog"
 	"github.com/dogmatiq/infix/parcel"
 	"github.com/dogmatiq/infix/persistence/subsystem/aggregatestore"
-	"github.com/dogmatiq/infix/persistence/subsystem/eventstore"
 	"github.com/dogmatiq/infix/pipeline"
 )
 
@@ -169,7 +168,7 @@ func (s *Sink) save(
 		return err
 	}
 
-	var offset eventstore.Offset
+	var offset uint64
 	for _, p := range sc.events {
 		offset, err = res.RecordEvent(ctx, tx, p)
 		if err != nil {

--- a/handler/aggregate/pipeline_test.go
+++ b/handler/aggregate/pipeline_test.go
@@ -478,7 +478,7 @@ var _ = Describe("type Sink", func() {
 				tx.SaveEventFunc = func(
 					context.Context,
 					*envelopespec.Envelope,
-				) (eventstore.Offset, error) {
+				) (uint64, error) {
 					return 0, errors.New("<error>")
 				}
 

--- a/handler/integration/pipeline_test.go
+++ b/handler/integration/pipeline_test.go
@@ -169,7 +169,7 @@ var _ = Describe("type Sink", func() {
 			tx.SaveEventFunc = func(
 				context.Context,
 				*envelopespec.Envelope,
-			) (eventstore.Offset, error) {
+			) (uint64, error) {
 				return 0, errors.New("<error>")
 			}
 

--- a/handler/projection/resource/resource.go
+++ b/handler/projection/resource/resource.go
@@ -31,7 +31,7 @@ func MarshalOffsetInto(buf []byte, o uint64) []byte {
 		return buf[:0]
 	}
 
-	binary.BigEndian.PutUint64(buf, uint64(o)-1)
+	binary.BigEndian.PutUint64(buf, o-1)
 
 	return buf[:8]
 }

--- a/handler/projection/resource/resource.go
+++ b/handler/projection/resource/resource.go
@@ -3,8 +3,6 @@ package resource
 import (
 	"encoding/binary"
 	"fmt"
-
-	"github.com/dogmatiq/infix/eventstream"
 )
 
 // FromApplicationKey returns the resource to use for the given application with
@@ -17,7 +15,7 @@ func FromApplicationKey(k string) []byte {
 //
 // o is the next offset to be read from the stream, not the last offset
 // that was applied to the projection.
-func MarshalOffset(o eventstream.Offset) []byte {
+func MarshalOffset(o uint64) []byte {
 	return MarshalOffsetInto(make([]byte, 8), o)
 }
 
@@ -28,7 +26,7 @@ func MarshalOffset(o eventstream.Offset) []byte {
 //
 // o is the next offset to be read from the stream, not the last offset that was
 // applied to the projection.
-func MarshalOffsetInto(buf []byte, o eventstream.Offset) []byte {
+func MarshalOffsetInto(buf []byte, o uint64) []byte {
 	if o == 0 {
 		return buf[:0]
 	}
@@ -42,14 +40,12 @@ func MarshalOffsetInto(buf []byte, o eventstream.Offset) []byte {
 //
 // It returns the next offset to be read from the stream, not the last offset
 // that was applied to the projection.
-func UnmarshalOffset(v []byte) (eventstream.Offset, error) {
+func UnmarshalOffset(v []byte) (uint64, error) {
 	switch len(v) {
 	case 0:
 		return 0, nil
 	case 8:
-		return eventstream.Offset(
-			binary.BigEndian.Uint64(v) + 1,
-		), nil
+		return binary.BigEndian.Uint64(v) + 1, nil
 	default:
 		return 0, fmt.Errorf(
 			"version is %d byte(s), expected 0 or 8",

--- a/handler/projection/stream.go
+++ b/handler/projection/stream.go
@@ -43,7 +43,7 @@ type StreamAdaptor struct {
 func (a *StreamAdaptor) NextOffset(
 	ctx context.Context,
 	id configkit.Identity,
-) (eventstream.Offset, error) {
+) (uint64, error) {
 	res := resource.FromApplicationKey(id.Key)
 
 	buf, err := a.Handler.ResourceVersion(ctx, res)
@@ -60,7 +60,7 @@ func (a *StreamAdaptor) NextOffset(
 // the next call to NextOffset() will return ev.Offset + 1.
 func (a *StreamAdaptor) HandleEvent(
 	ctx context.Context,
-	o eventstream.Offset,
+	o uint64,
 	ev *eventstream.Event,
 ) (err error) {
 	source := ev.Parcel.Envelope.MetaData.Source.Application

--- a/persistence/internal/providertest/aggregatestore/transaction.go
+++ b/persistence/internal/providertest/aggregatestore/transaction.go
@@ -184,7 +184,7 @@ func DeclareTransactionTests(tc *common.TestContext) {
 									&aggregatestore.MetaData{
 										HandlerKey: "<handler-key>",
 										InstanceID: "<instance>",
-										Revision:   aggregatestore.Revision(conflictingRevision),
+										Revision:   uint64(conflictingRevision),
 									},
 								)
 								gomega.Expect(err).To(gomega.Equal(aggregatestore.ErrConflict))
@@ -295,7 +295,7 @@ func DeclareTransactionTests(tc *common.TestContext) {
 									&aggregatestore.MetaData{
 										HandlerKey:  hk,
 										InstanceID:  id,
-										Revision:    aggregatestore.Revision(i),
+										Revision:    uint64(i),
 										BeginOffset: uint64(100 + i),
 										EndOffset:   uint64(200 + i),
 									},

--- a/persistence/internal/providertest/aggregatestore/transaction.go
+++ b/persistence/internal/providertest/aggregatestore/transaction.go
@@ -6,7 +6,6 @@ import (
 	"github.com/dogmatiq/infix/persistence"
 	"github.com/dogmatiq/infix/persistence/internal/providertest/common"
 	"github.com/dogmatiq/infix/persistence/subsystem/aggregatestore"
-	"github.com/dogmatiq/infix/persistence/subsystem/eventstore"
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/ginkgo/extensions/table"
 	"github.com/onsi/gomega"
@@ -297,8 +296,8 @@ func DeclareTransactionTests(tc *common.TestContext) {
 										HandlerKey:  hk,
 										InstanceID:  id,
 										Revision:    aggregatestore.Revision(i),
-										BeginOffset: eventstore.Offset(100 + i),
-										EndOffset:   eventstore.Offset(200 + i),
+										BeginOffset: uint64(100 + i),
+										EndOffset:   uint64(200 + i),
 									},
 								); err != nil {
 									return err

--- a/persistence/internal/providertest/eventstore/util.go
+++ b/persistence/internal/providertest/eventstore/util.go
@@ -14,7 +14,7 @@ func saveEvent(
 	ctx context.Context,
 	ds persistence.DataStore,
 	env *envelopespec.Envelope,
-) eventstore.Offset {
+) uint64 {
 	tx, err := ds.Begin(ctx)
 	gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 	defer tx.Rollback()

--- a/persistence/internal/providertest/offsetstore/repository.go
+++ b/persistence/internal/providertest/offsetstore/repository.go
@@ -3,7 +3,6 @@ package offsetstore
 import (
 	"context"
 
-	"github.com/dogmatiq/infix/eventstream"
 	"github.com/dogmatiq/infix/persistence"
 	"github.com/dogmatiq/infix/persistence/internal/providertest/common"
 	"github.com/dogmatiq/infix/persistence/subsystem/offsetstore"
@@ -44,16 +43,14 @@ func DeclareRepositoryTests(tc *common.TestContext) {
 
 			ginkgo.When("application has previous offsets associated", func() {
 				ginkgo.It("returns the current offset", func() {
-					c := eventstream.Offset(0)
-					n := eventstream.Offset(1)
-					saveOffset(tc.Context, dataStore, "<source-app-key>", c, n)
+					saveOffset(tc.Context, dataStore, "<source-app-key>", 0, 1)
 
 					actual, err := repository.LoadOffset(
 						tc.Context,
 						"<source-app-key>",
 					)
 					gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
-					gomega.Expect(actual).To(gomega.BeEquivalentTo(n))
+					gomega.Expect(actual).To(gomega.BeEquivalentTo(1))
 				})
 			})
 

--- a/persistence/internal/providertest/offsetstore/transaction.go
+++ b/persistence/internal/providertest/offsetstore/transaction.go
@@ -96,7 +96,7 @@ func DeclareTransactionTests(tc *common.TestContext) {
 
 				table.DescribeTable(
 					"it does not update the offset when an OCC conflict occurs",
-					func(conflictingOffset uint64) {
+					func(conflictingOffset int) {
 						err := persistence.WithTransaction(
 							tc.Context,
 							dataStore,
@@ -104,7 +104,7 @@ func DeclareTransactionTests(tc *common.TestContext) {
 								err := tx.SaveOffset(
 									tc.Context,
 									"<source-app-key>",
-									conflictingOffset,
+									uint64(conflictingOffset),
 									123,
 								)
 								gomega.Expect(err).To(gomega.Equal(offsetstore.ErrConflict))
@@ -117,9 +117,9 @@ func DeclareTransactionTests(tc *common.TestContext) {
 						actual := loadOffset(tc.Context, repository, "<source-app-key>")
 						gomega.Expect(actual).To(gomega.BeEquivalentTo(current))
 					},
-					table.Entry("zero", uint64(0)),
-					table.Entry("too low", uint64(1)),
-					table.Entry("too high", uint64(100)),
+					table.Entry("zero", 0),
+					table.Entry("too low", 1),
+					table.Entry("too high", 100),
 				)
 
 				ginkgo.It("does not save the offset when the transaction is rolled-back", func() {

--- a/persistence/internal/providertest/offsetstore/transaction.go
+++ b/persistence/internal/providertest/offsetstore/transaction.go
@@ -3,7 +3,6 @@ package offsetstore
 import (
 	"sync"
 
-	"github.com/dogmatiq/infix/eventstream"
 	"github.com/dogmatiq/infix/persistence"
 	"github.com/dogmatiq/infix/persistence/internal/providertest/common"
 	"github.com/dogmatiq/infix/persistence/subsystem/offsetstore"
@@ -34,23 +33,23 @@ func DeclareTransactionTests(tc *common.TestContext) {
 		ginkgo.Describe("func SaveOffset()", func() {
 			ginkgo.When("application has no previous offsets associated", func() {
 				ginkgo.It("saves an offset", func() {
-					c := eventstream.Offset(0)
-					n := eventstream.Offset(1)
-					saveOffset(tc.Context, dataStore, "<source-app-key>", c, n)
+					saveOffset(tc.Context, dataStore, "<source-app-key>", 0, 1)
 
 					actual := loadOffset(tc.Context, repository, "<source-app-key>")
-					gomega.Expect(actual).To(gomega.BeEquivalentTo(n))
+					gomega.Expect(actual).To(gomega.BeEquivalentTo(1))
 				})
 
 				ginkgo.It("it does not update the offset when an OCC conflict occurs", func() {
-					c := eventstream.Offset(1)
-					n := eventstream.Offset(2)
-
 					err := persistence.WithTransaction(
 						tc.Context,
 						dataStore,
 						func(tx persistence.ManagedTransaction) error {
-							return tx.SaveOffset(tc.Context, "<source-app-key>", c, n)
+							return tx.SaveOffset(
+								tc.Context,
+								"<source-app-key>",
+								1,
+								2,
+							)
 						},
 					)
 					gomega.Expect(err).To(gomega.Equal(offsetstore.ErrConflict))
@@ -60,9 +59,6 @@ func DeclareTransactionTests(tc *common.TestContext) {
 				})
 
 				ginkgo.It("does not save the offset when the transaction is rolled-back", func() {
-					c := eventstream.Offset(0)
-					n := eventstream.Offset(1)
-
 					err := common.WithTransactionRollback(
 						tc.Context,
 						dataStore,
@@ -70,25 +66,23 @@ func DeclareTransactionTests(tc *common.TestContext) {
 							return tx.SaveOffset(
 								tc.Context,
 								"<source-app-key>",
-								c,
-								n,
+								0,
+								1,
 							)
 						},
 					)
 					gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 
 					actual := loadOffset(tc.Context, repository, "<source-app-key>")
-					gomega.Expect(actual).To(gomega.BeEquivalentTo(c))
+					gomega.Expect(actual).To(gomega.BeEquivalentTo(0))
 				})
 			})
 
 			ginkgo.When("application has previous offsets associated", func() {
-				var (
-					current eventstream.Offset
-				)
+				var current uint64
 
 				ginkgo.BeforeEach(func() {
-					current = eventstream.Offset(0)
+					current = 0
 					saveOffset(tc.Context, dataStore, "<source-app-key>", current, 5)
 					current = 5
 				})
@@ -102,7 +96,7 @@ func DeclareTransactionTests(tc *common.TestContext) {
 
 				table.DescribeTable(
 					"it does not update the offset when an OCC conflict occurs",
-					func(conflictingOffset eventstream.Offset) {
+					func(conflictingOffset uint64) {
 						err := persistence.WithTransaction(
 							tc.Context,
 							dataStore,
@@ -123,9 +117,9 @@ func DeclareTransactionTests(tc *common.TestContext) {
 						actual := loadOffset(tc.Context, repository, "<source-app-key>")
 						gomega.Expect(actual).To(gomega.BeEquivalentTo(current))
 					},
-					table.Entry("zero", eventstream.Offset(0)),
-					table.Entry("too low", eventstream.Offset(1)),
-					table.Entry("too high", eventstream.Offset(100)),
+					table.Entry("zero", uint64(0)),
+					table.Entry("too low", uint64(1)),
+					table.Entry("too high", uint64(100)),
 				)
 
 				ginkgo.It("does not save the offset when the transaction is rolled-back", func() {
@@ -199,7 +193,7 @@ func DeclareTransactionTests(tc *common.TestContext) {
 				ginkgo.It("saves offsets concurrently", func() {
 					var g sync.WaitGroup
 
-					fn := func(ak string, n eventstream.Offset) {
+					fn := func(ak string, n uint64) {
 						defer ginkgo.GinkgoRecover()
 						defer g.Done()
 

--- a/persistence/internal/providertest/offsetstore/util.go
+++ b/persistence/internal/providertest/offsetstore/util.go
@@ -3,7 +3,6 @@ package offsetstore
 import (
 	"context"
 
-	"github.com/dogmatiq/infix/eventstream"
 	"github.com/dogmatiq/infix/persistence"
 	"github.com/dogmatiq/infix/persistence/subsystem/offsetstore"
 	"github.com/onsi/gomega"
@@ -15,7 +14,7 @@ func saveOffset(
 	ctx context.Context,
 	ds persistence.DataStore,
 	ak string,
-	c, n eventstream.Offset,
+	c, n uint64,
 ) {
 	err := persistence.WithTransaction(
 		ctx,
@@ -34,7 +33,7 @@ func loadOffset(
 	ctx context.Context,
 	repository offsetstore.Repository,
 	ak string,
-) eventstream.Offset {
+) uint64 {
 	o, err := repository.LoadOffset(ctx, ak)
 	gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 

--- a/persistence/internal/providertest/queuestore/transaction.go
+++ b/persistence/internal/providertest/queuestore/transaction.go
@@ -128,7 +128,7 @@ func DeclareTransactionTests(tc *common.TestContext) {
 							dataStore,
 							func(tx persistence.ManagedTransaction) error {
 								clone := *item0
-								clone.Revision = queuestore.Revision(conflictingRevision)
+								clone.Revision = uint64(conflictingRevision)
 								clone.NextAttemptAt = clone.NextAttemptAt.Add(1 * time.Hour)
 
 								err := tx.SaveMessageToQueue(tc.Context, &clone)
@@ -316,7 +316,7 @@ func DeclareTransactionTests(tc *common.TestContext) {
 							dataStore,
 							func(tx persistence.ManagedTransaction) error {
 								clone := *item0
-								clone.Revision = queuestore.Revision(conflictingRevision)
+								clone.Revision = uint64(conflictingRevision)
 
 								err := tx.RemoveMessageFromQueue(tc.Context, &clone)
 								gomega.Expect(err).To(gomega.Equal(queuestore.ErrConflict))
@@ -344,7 +344,7 @@ func DeclareTransactionTests(tc *common.TestContext) {
 							dataStore,
 							func(tx persistence.ManagedTransaction) error {
 								clone := *item0
-								clone.Revision = queuestore.Revision(conflictingRevision)
+								clone.Revision = uint64(conflictingRevision)
 
 								err := tx.RemoveMessageFromQueue(tc.Context, &clone)
 								gomega.Expect(err).To(gomega.Equal(queuestore.ErrConflict))

--- a/persistence/provider/boltdb/aggregatestore.go
+++ b/persistence/provider/boltdb/aggregatestore.go
@@ -6,7 +6,6 @@ import (
 	"github.com/dogmatiq/infix/internal/x/bboltx"
 	"github.com/dogmatiq/infix/persistence/provider/boltdb/internal/pb"
 	"github.com/dogmatiq/infix/persistence/subsystem/aggregatestore"
-	"github.com/dogmatiq/infix/persistence/subsystem/eventstore"
 	"github.com/golang/protobuf/proto"
 	"go.etcd.io/bbolt"
 )
@@ -104,8 +103,8 @@ func (r *aggregateStoreRepository) LoadMetaData(
 			if exists {
 				pb := loadAggregateStoreMetaData(metadata, id)
 				md.Revision = aggregatestore.Revision(pb.GetRevision())
-				md.BeginOffset = eventstore.Offset(pb.GetBeginOffset())
-				md.EndOffset = eventstore.Offset(pb.GetEndOffset())
+				md.BeginOffset = pb.GetBeginOffset()
+				md.EndOffset = pb.GetEndOffset()
 			}
 		},
 	)

--- a/persistence/provider/boltdb/aggregatestore.go
+++ b/persistence/provider/boltdb/aggregatestore.go
@@ -102,7 +102,7 @@ func (r *aggregateStoreRepository) LoadMetaData(
 
 			if exists {
 				pb := loadAggregateStoreMetaData(metadata, id)
-				md.Revision = aggregatestore.Revision(pb.GetRevision())
+				md.Revision = pb.GetRevision()
 				md.BeginOffset = pb.GetBeginOffset()
 				md.EndOffset = pb.GetEndOffset()
 			}

--- a/persistence/provider/boltdb/aggregatestore.go
+++ b/persistence/provider/boltdb/aggregatestore.go
@@ -58,7 +58,7 @@ func (t *transaction) SaveAggregateMetaData(
 
 	old := loadAggregateStoreMetaData(metadata, md.InstanceID)
 
-	if uint64(md.Revision) != old.GetRevision() {
+	if md.Revision != old.GetRevision() {
 		return aggregatestore.ErrConflict
 	}
 
@@ -116,7 +116,7 @@ func (r *aggregateStoreRepository) LoadMetaData(
 // representation with an incremented revision.
 func marshalAggregateStoreMetaData(md *aggregatestore.MetaData) []byte {
 	new := &pb.AggregateStoreMetaData{
-		Revision:    uint64(md.Revision + 1),
+		Revision:    md.Revision + 1,
 		BeginOffset: md.BeginOffset,
 		EndOffset:   md.EndOffset,
 	}

--- a/persistence/provider/boltdb/aggregatestore.go
+++ b/persistence/provider/boltdb/aggregatestore.go
@@ -118,8 +118,8 @@ func (r *aggregateStoreRepository) LoadMetaData(
 func marshalAggregateStoreMetaData(md *aggregatestore.MetaData) []byte {
 	new := &pb.AggregateStoreMetaData{
 		Revision:    uint64(md.Revision + 1),
-		BeginOffset: uint64(md.BeginOffset),
-		EndOffset:   uint64(md.EndOffset),
+		BeginOffset: md.BeginOffset,
+		EndOffset:   md.EndOffset,
 	}
 
 	data, err := proto.Marshal(new)

--- a/persistence/provider/boltdb/queuestore.go
+++ b/persistence/provider/boltdb/queuestore.go
@@ -73,7 +73,7 @@ func (t *transaction) SaveMessageToQueue(
 
 	old := loadQueueStoreItem(items, i.ID())
 
-	if uint64(i.Revision) != old.GetRevision() {
+	if i.Revision != old.GetRevision() {
 		return queuestore.ErrConflict
 	}
 
@@ -123,7 +123,7 @@ func (t *transaction) RemoveMessageFromQueue(
 
 	old := loadQueueStoreItem(items, i.ID())
 
-	if uint64(i.Revision) != old.GetRevision() {
+	if i.Revision != old.GetRevision() {
 		return queuestore.ErrConflict
 	}
 
@@ -227,7 +227,7 @@ func marshalQueueStoreItem(
 	old *pb.QueueStoreItem,
 ) (*pb.QueueStoreItem, []byte) {
 	new := &pb.QueueStoreItem{
-		Revision:      uint64(i.Revision + 1),
+		Revision:      i.Revision + 1,
 		FailureCount:  uint64(i.FailureCount),
 		NextAttemptAt: i.NextAttemptAt.Format(time.RFC3339Nano),
 		Envelope:      old.GetEnvelope(),

--- a/persistence/provider/boltdb/queuestore.go
+++ b/persistence/provider/boltdb/queuestore.go
@@ -213,7 +213,7 @@ func unmarshalQueueStoreItem(data []byte) *queuestore.Item {
 	bboltx.Must(err)
 
 	return &queuestore.Item{
-		Revision:      queuestore.Revision(i.Revision),
+		Revision:      i.Revision,
 		FailureCount:  uint(i.FailureCount),
 		NextAttemptAt: next,
 		Envelope:      i.Envelope,

--- a/persistence/provider/memory/aggregatestore.go
+++ b/persistence/provider/memory/aggregatestore.go
@@ -85,7 +85,7 @@ func (cs *aggregateStoreChangeSet) stageSave(
 
 	// Likewise, the "effective" revision is the revision as it appears
 	// including the changes in this transaction.
-	var effectiveRev aggregatestore.Revision
+	var effectiveRev uint64
 	if effective != nil {
 		effectiveRev = effective.Revision
 	}

--- a/persistence/provider/memory/eventstore.go
+++ b/persistence/provider/memory/eventstore.go
@@ -36,10 +36,10 @@ func (r *eventStoreRepository) NextEventOffset(
 		return 0, err
 	}
 
-	next := uint64(len(r.db.event.items))
+	next := len(r.db.event.items)
 	r.db.RUnlock()
 
-	return next, nil
+	return uint64(next), nil
 }
 
 // QueryEvents queries events in the repository.

--- a/persistence/provider/memory/eventstore.go
+++ b/persistence/provider/memory/eventstore.go
@@ -14,7 +14,7 @@ import (
 func (t *transaction) SaveEvent(
 	ctx context.Context,
 	env *envelopespec.Envelope,
-) (eventstore.Offset, error) {
+) (uint64, error) {
 	if err := t.begin(ctx); err != nil {
 		return 0, err
 	}
@@ -31,12 +31,12 @@ type eventStoreRepository struct {
 // NextEventOffset returns the next "unused" offset within the store.
 func (r *eventStoreRepository) NextEventOffset(
 	ctx context.Context,
-) (eventstore.Offset, error) {
+) (uint64, error) {
 	if err := r.db.RLock(ctx); err != nil {
 		return 0, err
 	}
 
-	next := eventstore.Offset(len(r.db.event.items))
+	next := uint64(len(r.db.event.items))
 	r.db.RUnlock()
 
 	return next, nil
@@ -112,10 +112,10 @@ type eventStoreChangeSet struct {
 func (cs *eventStoreChangeSet) stageSave(
 	db *eventStoreDatabase,
 	env *envelopespec.Envelope,
-) eventstore.Offset {
+) uint64 {
 	// Find the offset for the new event based on what's already in the database
 	// and the new events in this change-set.
-	next := eventstore.Offset(
+	next := uint64(
 		len(db.items) + len(cs.items),
 	)
 

--- a/persistence/provider/memory/queuestore.go
+++ b/persistence/provider/memory/queuestore.go
@@ -104,7 +104,7 @@ func (cs *queueStoreChangeSet) stageSave(
 
 	// Likewise, the "effective" revision is the revision as it appears
 	// including the changes in this transaction.
-	var effectiveRev queuestore.Revision
+	var effectiveRev uint64
 	if effective != nil {
 		// effective will be nil if the item is staged for removal, in which
 		// case the effective revision is 0 again.

--- a/persistence/provider/sql/eventstore.go
+++ b/persistence/provider/sql/eventstore.go
@@ -19,13 +19,13 @@ type eventStoreDriver interface {
 		ctx context.Context,
 		tx *sql.Tx,
 		ak string,
-	) (eventstore.Offset, error)
+	) (uint64, error)
 
 	// InsertEvent saves an event to the eventstore at a specific offset.
 	InsertEvent(
 		ctx context.Context,
 		tx *sql.Tx,
-		o eventstore.Offset,
+		o uint64,
 		env *envelopespec.Envelope,
 	) error
 
@@ -62,7 +62,7 @@ type eventStoreDriver interface {
 		ctx context.Context,
 		db *sql.DB,
 		ak string,
-	) (eventstore.Offset, error)
+	) (uint64, error)
 
 	// SelectEvents selects events from the eventstore that match the given
 	// query.
@@ -90,7 +90,7 @@ type eventStoreDriver interface {
 func (t *transaction) SaveEvent(
 	ctx context.Context,
 	env *envelopespec.Envelope,
-) (_ eventstore.Offset, err error) {
+) (_ uint64, err error) {
 	if err := t.begin(ctx); err != nil {
 		return 0, err
 	}
@@ -125,7 +125,7 @@ type eventStoreRepository struct {
 // NextEventOffset returns the next "unused" offset within the store.
 func (r *eventStoreRepository) NextEventOffset(
 	ctx context.Context,
-) (eventstore.Offset, error) {
+) (uint64, error) {
 	return r.driver.SelectNextEventOffset(
 		ctx,
 		r.db,

--- a/persistence/provider/sql/mysql/eventstore.go
+++ b/persistence/provider/sql/mysql/eventstore.go
@@ -16,7 +16,7 @@ func (driver) UpdateNextOffset(
 	ctx context.Context,
 	tx *sql.Tx,
 	ak string,
-) (_ eventstore.Offset, err error) {
+) (_ uint64, err error) {
 	defer sqlx.Recover(&err)
 
 	sqlx.Exec(
@@ -39,14 +39,14 @@ func (driver) UpdateNextOffset(
 		ak,
 	)
 
-	return eventstore.Offset(next), nil
+	return uint64(next), nil
 }
 
 // InsertEvent saves an event to the eventstore at a specific offset.
 func (driver) InsertEvent(
 	ctx context.Context,
 	tx *sql.Tx,
-	o eventstore.Offset,
+	o uint64,
 	env *envelopespec.Envelope,
 ) error {
 	_, err := tx.ExecContext(
@@ -160,7 +160,7 @@ func (driver) SelectNextEventOffset(
 	ctx context.Context,
 	db *sql.DB,
 	ak string,
-) (eventstore.Offset, error) {
+) (uint64, error) {
 	row := db.QueryRowContext(
 		ctx,
 		`SELECT
@@ -168,7 +168,7 @@ func (driver) SelectNextEventOffset(
 		FROM event_offset`,
 	)
 
-	var next eventstore.Offset
+	var next uint64
 
 	err := row.Scan(&next)
 	if err == sql.ErrNoRows {

--- a/persistence/provider/sql/mysql/offsetstore.go
+++ b/persistence/provider/sql/mysql/offsetstore.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 
-	"github.com/dogmatiq/infix/eventstream"
 	"github.com/dogmatiq/infix/internal/x/sqlx"
 )
 
@@ -17,7 +16,7 @@ func (driver) LoadOffset(
 	ctx context.Context,
 	db *sql.DB,
 	ak, sk string,
-) (eventstream.Offset, error) {
+) (uint64, error) {
 	row := db.QueryRowContext(
 		ctx,
 		`SELECT
@@ -29,7 +28,7 @@ func (driver) LoadOffset(
 		sk,
 	)
 
-	var o eventstream.Offset
+	var o uint64
 	err := row.Scan(&o)
 	if err == sql.ErrNoRows {
 		err = nil
@@ -46,7 +45,7 @@ func (driver) InsertOffset(
 	ctx context.Context,
 	tx *sql.Tx,
 	ak, sk string,
-	n eventstream.Offset,
+	n uint64,
 ) (bool, error) {
 	return insertIgnore(
 		ctx,
@@ -70,7 +69,7 @@ func (driver) UpdateOffset(
 	ctx context.Context,
 	tx *sql.Tx,
 	ak, sk string,
-	c, n eventstream.Offset,
+	c, n uint64,
 ) (_ bool, err error) {
 	defer sqlx.Recover(&err)
 

--- a/persistence/provider/sql/offsetstore.go
+++ b/persistence/provider/sql/offsetstore.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 
-	"github.com/dogmatiq/infix/eventstream"
 	"github.com/dogmatiq/infix/persistence/subsystem/offsetstore"
 )
 
@@ -20,7 +19,7 @@ type offsetStoreDriver interface {
 		ctx context.Context,
 		db *sql.DB,
 		ak, sk string,
-	) (eventstream.Offset, error)
+	) (uint64, error)
 
 	// InsertOffset inserts a new offset associated with the given source
 	// application key sk. ak is the 'owner' application key.
@@ -30,7 +29,7 @@ type offsetStoreDriver interface {
 		ctx context.Context,
 		tx *sql.Tx,
 		ak, sk string,
-		n eventstream.Offset,
+		n uint64,
 	) (bool, error)
 
 	// UpdateOffset updates the offset associated with the given source
@@ -42,7 +41,7 @@ type offsetStoreDriver interface {
 		ctx context.Context,
 		tx *sql.Tx,
 		ak, sk string,
-		c, n eventstream.Offset,
+		c, n uint64,
 	) (bool, error)
 }
 
@@ -51,7 +50,7 @@ type offsetStoreDriver interface {
 func (t *transaction) SaveOffset(
 	ctx context.Context,
 	ak string,
-	c, n eventstream.Offset,
+	c, n uint64,
 ) error {
 	if err := t.begin(ctx); err != nil {
 		return err
@@ -76,7 +75,7 @@ func (t *transaction) upsertOffset(
 	ctx context.Context,
 	tx *sql.Tx,
 	sk string,
-	c, n eventstream.Offset,
+	c, n uint64,
 ) (bool, error) {
 	if c > 0 {
 		return t.ds.driver.UpdateOffset(
@@ -110,6 +109,6 @@ type offsetStoreRepository struct {
 func (r *offsetStoreRepository) LoadOffset(
 	ctx context.Context,
 	ak string,
-) (eventstream.Offset, error) {
+) (uint64, error) {
 	return r.d.LoadOffset(ctx, r.db, r.appKey, ak)
 }

--- a/persistence/provider/sql/postgres/error.go
+++ b/persistence/provider/sql/postgres/error.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 
 	"github.com/dogmatiq/infix/draftspecs/envelopespec"
-	"github.com/dogmatiq/infix/eventstream"
 	"github.com/dogmatiq/infix/persistence/subsystem/aggregatestore"
 	"github.com/dogmatiq/infix/persistence/subsystem/eventstore"
 	"github.com/dogmatiq/infix/persistence/subsystem/queuestore"
@@ -188,7 +187,7 @@ func (d errorConverter) LoadOffset(
 	ctx context.Context,
 	db *sql.DB,
 	ak, sk string,
-) (eventstream.Offset, error) {
+) (uint64, error) {
 	o, err := d.d.LoadOffset(ctx, db, ak, sk)
 	return o, convertContextErrors(ctx, err)
 }
@@ -197,7 +196,7 @@ func (d errorConverter) InsertOffset(
 	ctx context.Context,
 	tx *sql.Tx,
 	ak, sk string,
-	n eventstream.Offset,
+	n uint64,
 ) (bool, error) {
 	ok, err := d.d.InsertOffset(ctx, tx, ak, sk, n)
 	return ok, convertContextErrors(ctx, err)
@@ -207,7 +206,7 @@ func (d errorConverter) UpdateOffset(
 	ctx context.Context,
 	tx *sql.Tx,
 	ak, sk string,
-	c, n eventstream.Offset,
+	c, n uint64,
 ) (bool, error) {
 	ok, err := d.d.UpdateOffset(ctx, tx, ak, sk, c, n)
 	return ok, convertContextErrors(ctx, err)

--- a/persistence/provider/sql/postgres/error.go
+++ b/persistence/provider/sql/postgres/error.go
@@ -109,7 +109,7 @@ func (d errorConverter) UpdateNextOffset(
 	ctx context.Context,
 	tx *sql.Tx,
 	ak string,
-) (eventstore.Offset, error) {
+) (uint64, error) {
 	o, err := d.d.UpdateNextOffset(ctx, tx, ak)
 	return o, convertContextErrors(ctx, err)
 }
@@ -117,7 +117,7 @@ func (d errorConverter) UpdateNextOffset(
 func (d errorConverter) InsertEvent(
 	ctx context.Context,
 	tx *sql.Tx,
-	o eventstore.Offset,
+	o uint64,
 	env *envelopespec.Envelope,
 ) error {
 	err := d.d.InsertEvent(ctx, tx, o, env)
@@ -156,7 +156,7 @@ func (d errorConverter) SelectNextEventOffset(
 	ctx context.Context,
 	db *sql.DB,
 	ak string,
-) (eventstore.Offset, error) {
+) (uint64, error) {
 	next, err := d.d.SelectNextEventOffset(ctx, db, ak)
 	return next, convertContextErrors(ctx, err)
 }

--- a/persistence/provider/sql/postgres/eventstore.go
+++ b/persistence/provider/sql/postgres/eventstore.go
@@ -16,7 +16,7 @@ func (driver) UpdateNextOffset(
 	ctx context.Context,
 	tx *sql.Tx,
 	ak string,
-) (_ eventstore.Offset, err error) {
+) (_ uint64, err error) {
 	defer sqlx.Recover(&err)
 
 	o := sqlx.QueryInt64(
@@ -32,14 +32,14 @@ func (driver) UpdateNextOffset(
 		ak,
 	)
 
-	return eventstore.Offset(o), nil
+	return uint64(o), nil
 }
 
 // InsertEvent saves an event to the eventstore at a specific offset.
 func (driver) InsertEvent(
 	ctx context.Context,
 	tx *sql.Tx,
-	o eventstore.Offset,
+	o uint64,
 	env *envelopespec.Envelope,
 ) error {
 	_, err := tx.ExecContext(
@@ -162,7 +162,7 @@ func (driver) SelectNextEventOffset(
 	ctx context.Context,
 	db *sql.DB,
 	ak string,
-) (eventstore.Offset, error) {
+) (uint64, error) {
 	row := db.QueryRowContext(
 		ctx,
 		`SELECT
@@ -170,7 +170,7 @@ func (driver) SelectNextEventOffset(
 		FROM infix.event_offset`,
 	)
 
-	var next eventstore.Offset
+	var next uint64
 
 	err := row.Scan(&next)
 	if err == sql.ErrNoRows {

--- a/persistence/provider/sql/postgres/offsetstore.go
+++ b/persistence/provider/sql/postgres/offsetstore.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 
-	"github.com/dogmatiq/infix/eventstream"
 	"github.com/dogmatiq/infix/internal/x/sqlx"
 )
 
@@ -17,7 +16,7 @@ func (driver) LoadOffset(
 	ctx context.Context,
 	db *sql.DB,
 	ak, sk string,
-) (eventstream.Offset, error) {
+) (uint64, error) {
 	row := db.QueryRowContext(
 		ctx,
 		`SELECT
@@ -29,7 +28,7 @@ func (driver) LoadOffset(
 		sk,
 	)
 
-	var o eventstream.Offset
+	var o uint64
 	err := row.Scan(&o)
 	if err == sql.ErrNoRows {
 		err = nil
@@ -46,7 +45,7 @@ func (driver) InsertOffset(
 	ctx context.Context,
 	tx *sql.Tx,
 	ak, sk string,
-	n eventstream.Offset,
+	n uint64,
 ) (bool, error) {
 	res, err := tx.ExecContext(
 		ctx,
@@ -78,7 +77,7 @@ func (driver) UpdateOffset(
 	ctx context.Context,
 	tx *sql.Tx,
 	ak, sk string,
-	c, n eventstream.Offset,
+	c, n uint64,
 ) (_ bool, err error) {
 	defer sqlx.Recover(&err)
 

--- a/persistence/provider/sql/sqlite/eventstore.go
+++ b/persistence/provider/sql/sqlite/eventstore.go
@@ -16,7 +16,7 @@ func (driver) UpdateNextOffset(
 	ctx context.Context,
 	tx *sql.Tx,
 	ak string,
-) (_ eventstore.Offset, err error) {
+) (_ uint64, err error) {
 	defer sqlx.Recover(&err)
 
 	sqlx.Exec(
@@ -41,14 +41,14 @@ func (driver) UpdateNextOffset(
 		ak,
 	)
 
-	return eventstore.Offset(next), nil
+	return uint64(next), nil
 }
 
 // InsertEvent saves an event to the eventstore at a specific offset.
 func (driver) InsertEvent(
 	ctx context.Context,
 	tx *sql.Tx,
-	o eventstore.Offset,
+	o uint64,
 	env *envelopespec.Envelope,
 ) error {
 	_, err := tx.ExecContext(
@@ -203,7 +203,7 @@ func (driver) SelectNextEventOffset(
 	ctx context.Context,
 	db *sql.DB,
 	ak string,
-) (eventstore.Offset, error) {
+) (uint64, error) {
 	row := db.QueryRowContext(
 		ctx,
 		`SELECT
@@ -211,7 +211,7 @@ func (driver) SelectNextEventOffset(
 		FROM event_offset`,
 	)
 
-	var next eventstore.Offset
+	var next uint64
 
 	err := row.Scan(&next)
 	if err == sql.ErrNoRows {

--- a/persistence/provider/sql/sqlite/offsetstore.go
+++ b/persistence/provider/sql/sqlite/offsetstore.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 
-	"github.com/dogmatiq/infix/eventstream"
 	"github.com/dogmatiq/infix/internal/x/sqlx"
 )
 
@@ -17,7 +16,7 @@ func (driver) LoadOffset(
 	ctx context.Context,
 	db *sql.DB,
 	ak, sk string,
-) (eventstream.Offset, error) {
+) (uint64, error) {
 	row := db.QueryRowContext(
 		ctx,
 		`SELECT
@@ -29,7 +28,7 @@ func (driver) LoadOffset(
 		sk,
 	)
 
-	var o eventstream.Offset
+	var o uint64
 	err := row.Scan(&o)
 	if err == sql.ErrNoRows {
 		err = nil
@@ -46,7 +45,7 @@ func (driver) InsertOffset(
 	ctx context.Context,
 	tx *sql.Tx,
 	ak, sk string,
-	n eventstream.Offset,
+	n uint64,
 ) (bool, error) {
 	res, err := tx.ExecContext(
 		ctx,
@@ -78,7 +77,7 @@ func (driver) UpdateOffset(
 	ctx context.Context,
 	tx *sql.Tx,
 	ak, sk string,
-	c, n eventstream.Offset,
+	c, n uint64,
 ) (_ bool, err error) {
 	defer sqlx.Recover(&err)
 

--- a/persistence/subsystem/aggregatestore/metadata.go
+++ b/persistence/subsystem/aggregatestore/metadata.go
@@ -1,9 +1,5 @@
 package aggregatestore
 
-// Revision is the version of an aggregate instance, used for optimistic
-// concurrency control.
-type Revision uint64
-
 // MetaData contains meta-data about an aggregate instance.
 type MetaData struct {
 	// HandlerKey is the identity key of the aggregate message handler.
@@ -14,7 +10,7 @@ type MetaData struct {
 
 	// Revision is the instance's version, used to enforce optimistic
 	// concurrency control.
-	Revision Revision
+	Revision uint64
 
 	// BeginOffset specifies the (inclusive) lower-bound of the event offsets
 	// that should be considered when loading the instance's historical events.

--- a/persistence/subsystem/aggregatestore/metadata.go
+++ b/persistence/subsystem/aggregatestore/metadata.go
@@ -1,7 +1,5 @@
 package aggregatestore
 
-import "github.com/dogmatiq/infix/persistence/subsystem/eventstore"
-
 // Revision is the version of an aggregate instance, used for optimistic
 // concurrency control.
 type Revision uint64
@@ -28,7 +26,7 @@ type MetaData struct {
 	// preventing any events that were recorded prior destruction from being
 	// "seen" by the handler in the future, without actually deleting historical
 	// events.
-	BeginOffset eventstore.Offset
+	BeginOffset uint64
 
 	// EndOffset specifies the (exclusive) upper-bound of the offset range that
 	// should be searched when reading the instance's historical events.
@@ -38,7 +36,7 @@ type MetaData struct {
 	//
 	// If non-zero, EndOffset is the offset after the last event recorded by
 	// the instance.
-	EndOffset eventstore.Offset
+	EndOffset uint64
 }
 
 // InstanceExists returns true if the instance exists.
@@ -54,6 +52,6 @@ func (md *MetaData) MarkInstanceDestroyed() {
 
 // SetLastRecordedOffset updates the meta-data to reflect that o was the offset
 // of the most-recent event recorded by the instance.
-func (md *MetaData) SetLastRecordedOffset(o eventstore.Offset) {
+func (md *MetaData) SetLastRecordedOffset(o uint64) {
 	md.EndOffset = o + 1
 }

--- a/persistence/subsystem/eventstore/item.go
+++ b/persistence/subsystem/eventstore/item.go
@@ -4,12 +4,9 @@ import (
 	"github.com/dogmatiq/infix/draftspecs/envelopespec"
 )
 
-// Offset is the position of an event within the store.
-type Offset = uint64
-
 // Item is a message persisted in the event store.
 type Item struct {
-	Offset   Offset
+	Offset   uint64
 	Envelope *envelopespec.Envelope
 }
 

--- a/persistence/subsystem/eventstore/item.go
+++ b/persistence/subsystem/eventstore/item.go
@@ -5,7 +5,7 @@ import (
 )
 
 // Offset is the position of an event within the store.
-type Offset uint64
+type Offset = uint64
 
 // Item is a message persisted in the event store.
 type Item struct {

--- a/persistence/subsystem/eventstore/repository.go
+++ b/persistence/subsystem/eventstore/repository.go
@@ -7,7 +7,7 @@ import (
 // Repository is an interface for reading persisted event messages.
 type Repository interface {
 	// NextEventOffset returns the next "unused" offset within the store.
-	NextEventOffset(ctx context.Context) (Offset, error)
+	NextEventOffset(ctx context.Context) (uint64, error)
 
 	// QueryEvents queries events in the repository.
 	QueryEvents(ctx context.Context, q Query) (Result, error)
@@ -45,7 +45,7 @@ func (f Filter) Remove(n string) {
 type Query struct {
 	// MinOffset specifies the (inclusive) lower-bound of the offset range to
 	// include in the results.
-	MinOffset Offset
+	MinOffset uint64
 
 	// Filter is the set of event types to include in the results, specified
 	// using the "portable type name".

--- a/persistence/subsystem/eventstore/transaction.go
+++ b/persistence/subsystem/eventstore/transaction.go
@@ -15,5 +15,5 @@ type Transaction interface {
 	SaveEvent(
 		ctx context.Context,
 		env *envelopespec.Envelope,
-	) (Offset, error)
+	) (uint64, error)
 }

--- a/persistence/subsystem/offsetstore/repository.go
+++ b/persistence/subsystem/offsetstore/repository.go
@@ -2,8 +2,6 @@ package offsetstore
 
 import (
 	"context"
-
-	"github.com/dogmatiq/infix/eventstream"
 )
 
 // Repository is an interface for reading persisted offsets.
@@ -11,5 +9,5 @@ type Repository interface {
 	// LoadOffset loads the offset associated with a specific application.
 	//
 	// ak is the application's identity key.
-	LoadOffset(ctx context.Context, ak string) (eventstream.Offset, error)
+	LoadOffset(ctx context.Context, ak string) (uint64, error)
 }

--- a/persistence/subsystem/offsetstore/transaction.go
+++ b/persistence/subsystem/offsetstore/transaction.go
@@ -3,8 +3,6 @@ package offsetstore
 import (
 	"context"
 	"errors"
-
-	"github.com/dogmatiq/infix/eventstream"
 )
 
 // ErrConflict is returned by transaction operations when a persisted
@@ -20,12 +18,12 @@ type Transaction interface {
 	//
 	// ak is the application's identity key.
 	//
-	// c must be the offset currently associated with ak, otherwise an optimistic
-	// concurrency conflict has occurred, the offset is not saved and ErrConflict
-	// is returned.
+	// c must be the offset currently associated with ak, otherwise an
+	// optimistic concurrency conflict has occurred, the offset is not saved and
+	// ErrConflict is returned.
 	SaveOffset(
 		ctx context.Context,
 		ak string,
-		c, n eventstream.Offset,
+		c, n uint64,
 	) error
 }

--- a/persistence/subsystem/queuestore/item.go
+++ b/persistence/subsystem/queuestore/item.go
@@ -6,13 +6,9 @@ import (
 	"github.com/dogmatiq/infix/draftspecs/envelopespec"
 )
 
-// Revision is the version of a message on the queue, used for optimistic
-// concurrency control.
-type Revision uint64
-
 // Item is a message persisted in the queue store.
 type Item struct {
-	Revision      Revision
+	Revision      uint64
 	FailureCount  uint
 	NextAttemptAt time.Time
 	Envelope      *envelopespec.Envelope

--- a/pipeline/response.go
+++ b/pipeline/response.go
@@ -56,7 +56,7 @@ func (r *Response) RecordEvent(
 	ctx context.Context,
 	tx persistence.ManagedTransaction,
 	p *parcel.Parcel,
-) (eventstore.Offset, error) {
+) (uint64, error) {
 	o, err := tx.SaveEvent(ctx, p.Envelope)
 	if err != nil {
 		return 0, err

--- a/pipeline/response_test.go
+++ b/pipeline/response_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/dogmatiq/infix/draftspecs/envelopespec"
 	. "github.com/dogmatiq/infix/fixtures"
 	"github.com/dogmatiq/infix/parcel"
-	"github.com/dogmatiq/infix/persistence/subsystem/eventstore"
 	"github.com/dogmatiq/infix/persistence/subsystem/queuestore"
 	. "github.com/dogmatiq/infix/pipeline"
 	. "github.com/jmalloc/gomegax"
@@ -104,7 +103,7 @@ var _ = Describe("type Response", func() {
 			tx.SaveEventFunc = func(
 				_ context.Context,
 				env *envelopespec.Envelope,
-			) (eventstore.Offset, error) {
+			) (uint64, error) {
 				called = true
 				Expect(env).To(EqualX(pcl.Envelope))
 				return 0, nil
@@ -119,7 +118,7 @@ var _ = Describe("type Response", func() {
 			tx.SaveEventFunc = func(
 				context.Context,
 				*envelopespec.Envelope,
-			) (eventstore.Offset, error) {
+			) (uint64, error) {
 				return 123, nil
 			}
 
@@ -132,7 +131,7 @@ var _ = Describe("type Response", func() {
 			tx.SaveEventFunc = func(
 				context.Context,
 				*envelopespec.Envelope,
-			) (eventstore.Offset, error) {
+			) (uint64, error) {
 				return 0, errors.New("<error>")
 			}
 


### PR DESCRIPTION
Fixes #172 

Ok, I bit the bullet and just did this. Like I was saying, all the casting between the offset types (and `uint64` from protobuf) really diminished the utility of these types and they just contributed to tighter coupling between packages than we really necessary.

I've also removed the `Revision` types while I was at it, because as on #220 they would have contributed the same kind of problem.

These graphs can be a bit misleading, but just to illustrate the coupling between packages, here is the graph from `master`:

![graph-master](https://user-images.githubusercontent.com/761536/80422052-d0026c80-8920-11ea-9511-1fa433598302.png)

And the graph as of this PR:

![graph](https://user-images.githubusercontent.com/761536/80422069-d55fb700-8920-11ea-9b3b-e7988b0cc2f3.png)
