### PR TITLE
Change `networkstream.server` source messages from a stream.

### DIFF
--- a/network.go
+++ b/network.go
@@ -67,7 +67,7 @@ func (e *Engine) registerEventStreamServer(ctx context.Context, s *grpc.Server) 
 			options,
 			networkstream.WithApplication(
 				k,
-				a.DataStore.EventStoreRepository(),
+				a.Stream,
 				a.Config.
 					MessageTypes().
 					Produced.


### PR DESCRIPTION
This change essentially reverts #75 by returning to serving events from a stream, rather than reading from a store (though the overall structure of the server remains much better) than it was before #75.

Once #233 and #230 are merged, the network server can use the `persistedstream` as the source of it's messages, and that will take care of shifting between reading from the store and the in memory cache.