### PR TITLE
Add `TransactionResult` type.

### DIFF
--- a/eventstream/persistedstream/stream_test.go
+++ b/eventstream/persistedstream/stream_test.go
@@ -42,7 +42,7 @@ var _ = Describe("type Stream", func() {
 			return streamtest.Out{
 				Stream: stream,
 				Append: func(ctx context.Context, parcels ...*parcel.Parcel) {
-					err := persistence.WithTransaction(
+					_, err := persistence.WithTransaction(
 						ctx,
 						dataStore,
 						func(tx persistence.ManagedTransaction) error {
@@ -59,7 +59,6 @@ var _ = Describe("type Stream", func() {
 									},
 								})
 							}
-
 							return nil
 						},
 					)

--- a/fixtures/persistence.go
+++ b/fixtures/persistence.go
@@ -183,7 +183,7 @@ type TransactionStub struct {
 	SaveMessageToQueueFunc     func(context.Context, *queuestore.Item) error
 	RemoveMessageFromQueueFunc func(context.Context, *queuestore.Item) error
 
-	CommitFunc   func(context.Context) error
+	CommitFunc   func(context.Context) (*persistence.TransactionResult, error)
 	RollbackFunc func() error
 }
 
@@ -259,7 +259,9 @@ func (t *TransactionStub) RemoveMessageFromQueue(ctx context.Context, i *queuest
 }
 
 // Commit applies the changes from the transaction.
-func (t *TransactionStub) Commit(ctx context.Context) error {
+func (t *TransactionStub) Commit(
+	ctx context.Context,
+) (*persistence.TransactionResult, error) {
 	if t.CommitFunc != nil {
 		return t.CommitFunc(ctx)
 	}
@@ -268,7 +270,7 @@ func (t *TransactionStub) Commit(ctx context.Context) error {
 		return t.Transaction.Commit(ctx)
 	}
 
-	return nil
+	return nil, nil
 }
 
 // Rollback aborts the transaction.

--- a/fixtures/persistence.go
+++ b/fixtures/persistence.go
@@ -183,7 +183,7 @@ type TransactionStub struct {
 	SaveMessageToQueueFunc     func(context.Context, *queuestore.Item) error
 	RemoveMessageFromQueueFunc func(context.Context, *queuestore.Item) error
 
-	CommitFunc   func(context.Context) (*persistence.TransactionResult, error)
+	CommitFunc   func(context.Context) (persistence.TransactionResult, error)
 	RollbackFunc func() error
 }
 
@@ -261,7 +261,7 @@ func (t *TransactionStub) RemoveMessageFromQueue(ctx context.Context, i *queuest
 // Commit applies the changes from the transaction.
 func (t *TransactionStub) Commit(
 	ctx context.Context,
-) (*persistence.TransactionResult, error) {
+) (persistence.TransactionResult, error) {
 	if t.CommitFunc != nil {
 		return t.CommitFunc(ctx)
 	}
@@ -270,7 +270,7 @@ func (t *TransactionStub) Commit(
 		return t.Transaction.Commit(ctx)
 	}
 
-	return nil, nil
+	return persistence.TransactionResult{}, nil
 }
 
 // Rollback aborts the transaction.

--- a/fixtures/pipeline.go
+++ b/fixtures/pipeline.go
@@ -58,7 +58,8 @@ func NewPipelineRequestStub(
 			return tx, nil
 		},
 		AckFunc: func(ctx context.Context) error {
-			return tx.Commit(ctx)
+			_, err := tx.Commit(ctx)
+			return err
 		},
 		CloseFunc: func() error {
 			return tx.Rollback()

--- a/handler/aggregate/loader_test.go
+++ b/handler/aggregate/loader_test.go
@@ -107,7 +107,7 @@ var _ = Describe("type Loader", func() {
 					InstanceID: "<instance>",
 				}
 
-				err := persistence.WithTransaction(
+				_, err := persistence.WithTransaction(
 					ctx,
 					dataStore,
 					func(tx persistence.ManagedTransaction) error {
@@ -184,7 +184,7 @@ var _ = Describe("type Loader", func() {
 
 			When("the instance has been destroyed", func() {
 				BeforeEach(func() {
-					err := persistence.WithTransaction(
+					_, err := persistence.WithTransaction(
 						ctx,
 						dataStore,
 						func(tx persistence.ManagedTransaction) error {
@@ -209,7 +209,7 @@ var _ = Describe("type Loader", func() {
 				})
 
 				It("only loads events that were recorded after the destruction", func() {
-					err := persistence.WithTransaction(
+					_, err := persistence.WithTransaction(
 						ctx,
 						dataStore,
 						func(tx persistence.ManagedTransaction) error {

--- a/persistence/internal/providertest/aggregatestore/transaction.go
+++ b/persistence/internal/providertest/aggregatestore/transaction.go
@@ -69,7 +69,7 @@ func DeclareTransactionTests(tc *common.TestContext) {
 				})
 
 				ginkgo.It("does not save the message when an OCC conflict occurs", func() {
-					err := persistence.WithTransaction(
+					_, err := persistence.WithTransaction(
 						tc.Context,
 						dataStore,
 						func(tx persistence.ManagedTransaction) error {
@@ -175,7 +175,7 @@ func DeclareTransactionTests(tc *common.TestContext) {
 							},
 						)
 
-						err := persistence.WithTransaction(
+						_, err := persistence.WithTransaction(
 							tc.Context,
 							dataStore,
 							func(tx persistence.ManagedTransaction) error {
@@ -205,7 +205,7 @@ func DeclareTransactionTests(tc *common.TestContext) {
 
 			ginkgo.When("an instance's meta-data is saved more than once in the same transaction", func() {
 				ginkgo.It("saves the meta-data from the most recent call", func() {
-					err := persistence.WithTransaction(
+					_, err := persistence.WithTransaction(
 						tc.Context,
 						dataStore,
 						func(tx persistence.ManagedTransaction) error {
@@ -285,7 +285,7 @@ func DeclareTransactionTests(tc *common.TestContext) {
 					defer ginkgo.GinkgoRecover()
 					defer g.Done()
 
-					err := persistence.WithTransaction(
+					_, err := persistence.WithTransaction(
 						tc.Context,
 						dataStore,
 						func(tx persistence.ManagedTransaction) error {

--- a/persistence/internal/providertest/aggregatestore/util.go
+++ b/persistence/internal/providertest/aggregatestore/util.go
@@ -26,7 +26,7 @@ func saveMetaData(
 	ds persistence.DataStore,
 	md *aggregatestore.MetaData,
 ) {
-	err := persistence.WithTransaction(
+	_, err := persistence.WithTransaction(
 		ctx,
 		ds,
 		func(tx persistence.ManagedTransaction) error {

--- a/persistence/internal/providertest/datastore.go
+++ b/persistence/internal/providertest/datastore.go
@@ -124,7 +124,8 @@ func declareDataStoreTests(
 
 						if commit {
 							ginkgo.By("committing the transaction")
-							result <- tx.Commit(*ctx)
+							_, err := tx.Commit(*ctx)
+							result <- err
 						} else {
 							ginkgo.By("rolling the transaction back")
 							result <- tx.Rollback()

--- a/persistence/internal/providertest/eventstore/transaction.go
+++ b/persistence/internal/providertest/eventstore/transaction.go
@@ -51,7 +51,7 @@ func DeclareTransactionTests(tc *common.TestContext) {
 			})
 
 			ginkgo.It("returns the offset of the event for subsequent calls in the same transaction", func() {
-				err := persistence.WithTransaction(
+				_, err := persistence.WithTransaction(
 					tc.Context,
 					dataStore,
 					func(tx persistence.ManagedTransaction) error {

--- a/persistence/internal/providertest/eventstore/util.go
+++ b/persistence/internal/providertest/eventstore/util.go
@@ -17,7 +17,7 @@ func saveEvent(
 ) uint64 {
 	var offset uint64
 
-	err := persistence.WithTransaction(
+	_, err := persistence.WithTransaction(
 		ctx,
 		ds,
 		func(tx persistence.ManagedTransaction) error {
@@ -37,7 +37,7 @@ func saveEvents(
 	ds persistence.DataStore,
 	envelopes ...*envelopespec.Envelope,
 ) {
-	err := persistence.WithTransaction(
+	_, err := persistence.WithTransaction(
 		ctx,
 		ds,
 		func(tx persistence.ManagedTransaction) error {

--- a/persistence/internal/providertest/offsetstore/transaction.go
+++ b/persistence/internal/providertest/offsetstore/transaction.go
@@ -40,7 +40,7 @@ func DeclareTransactionTests(tc *common.TestContext) {
 				})
 
 				ginkgo.It("it does not update the offset when an OCC conflict occurs", func() {
-					err := persistence.WithTransaction(
+					_, err := persistence.WithTransaction(
 						tc.Context,
 						dataStore,
 						func(tx persistence.ManagedTransaction) error {
@@ -97,7 +97,7 @@ func DeclareTransactionTests(tc *common.TestContext) {
 				table.DescribeTable(
 					"it does not update the offset when an OCC conflict occurs",
 					func(conflictingOffset int) {
-						err := persistence.WithTransaction(
+						_, err := persistence.WithTransaction(
 							tc.Context,
 							dataStore,
 							func(tx persistence.ManagedTransaction) error {
@@ -144,7 +144,7 @@ func DeclareTransactionTests(tc *common.TestContext) {
 
 			ginkgo.When("called multiple times within the same transaction", func() {
 				ginkgo.It("saves the last offset", func() {
-					err := persistence.WithTransaction(
+					_, err := persistence.WithTransaction(
 						tc.Context,
 						dataStore,
 						func(tx persistence.ManagedTransaction) error {
@@ -197,7 +197,7 @@ func DeclareTransactionTests(tc *common.TestContext) {
 						defer ginkgo.GinkgoRecover()
 						defer g.Done()
 
-						err := persistence.WithTransaction(
+						_, err := persistence.WithTransaction(
 							tc.Context,
 							dataStore,
 							func(tx persistence.ManagedTransaction) error {

--- a/persistence/internal/providertest/offsetstore/util.go
+++ b/persistence/internal/providertest/offsetstore/util.go
@@ -16,7 +16,7 @@ func saveOffset(
 	ak string,
 	c, n uint64,
 ) {
-	err := persistence.WithTransaction(
+	_, err := persistence.WithTransaction(
 		ctx,
 		ds,
 		func(tx persistence.ManagedTransaction) error {

--- a/persistence/internal/providertest/queuestore/transaction.go
+++ b/persistence/internal/providertest/queuestore/transaction.go
@@ -123,7 +123,7 @@ func DeclareTransactionTests(tc *common.TestContext) {
 						// too-low value.
 						saveMessages(tc.Context, dataStore, item0)
 
-						err := persistence.WithTransaction(
+						_, err := persistence.WithTransaction(
 							tc.Context,
 							dataStore,
 							func(tx persistence.ManagedTransaction) error {
@@ -192,7 +192,7 @@ func DeclareTransactionTests(tc *common.TestContext) {
 				ginkgo.It("does not save the message when an OCC conflict occurs", func() {
 					item0.Revision = 123
 
-					err := persistence.WithTransaction(
+					_, err := persistence.WithTransaction(
 						tc.Context,
 						dataStore,
 						func(tx persistence.ManagedTransaction) error {
@@ -210,7 +210,7 @@ func DeclareTransactionTests(tc *common.TestContext) {
 
 			ginkgo.When("a message is saved more than once in the same transaction", func() {
 				ginkgo.It("saves the meta-data from the most recent call", func() {
-					err := persistence.WithTransaction(
+					_, err := persistence.WithTransaction(
 						tc.Context,
 						dataStore,
 						func(tx persistence.ManagedTransaction) error {
@@ -251,7 +251,7 @@ func DeclareTransactionTests(tc *common.TestContext) {
 			})
 
 			ginkgo.It("does not update the revision field of the argument", func() {
-				err := persistence.WithTransaction(
+				_, err := persistence.WithTransaction(
 					tc.Context,
 					dataStore,
 					func(tx persistence.ManagedTransaction) error {
@@ -311,7 +311,7 @@ func DeclareTransactionTests(tc *common.TestContext) {
 						// too-low value.
 						saveMessages(tc.Context, dataStore, item0)
 
-						err := persistence.WithTransaction(
+						_, err := persistence.WithTransaction(
 							tc.Context,
 							dataStore,
 							func(tx persistence.ManagedTransaction) error {
@@ -339,7 +339,7 @@ func DeclareTransactionTests(tc *common.TestContext) {
 				table.DescribeTable(
 					"returns an OCC conflict error",
 					func(conflictingRevision int) {
-						err := persistence.WithTransaction(
+						_, err := persistence.WithTransaction(
 							tc.Context,
 							dataStore,
 							func(tx persistence.ManagedTransaction) error {
@@ -367,7 +367,7 @@ func DeclareTransactionTests(tc *common.TestContext) {
 
 			ginkgo.When("a message is saved then deleted in the same transaction", func() {
 				ginkgo.It("does not save the new message", func() {
-					err := persistence.WithTransaction(
+					_, err := persistence.WithTransaction(
 						tc.Context,
 						dataStore,
 						func(tx persistence.ManagedTransaction) error {
@@ -410,7 +410,7 @@ func DeclareTransactionTests(tc *common.TestContext) {
 				})
 
 				ginkgo.It("saves the new message", func() {
-					err := persistence.WithTransaction(
+					_, err := persistence.WithTransaction(
 						tc.Context,
 						dataStore,
 						func(tx persistence.ManagedTransaction) error {

--- a/persistence/internal/providertest/queuestore/util.go
+++ b/persistence/internal/providertest/queuestore/util.go
@@ -15,7 +15,7 @@ func saveMessages(
 	ds persistence.DataStore,
 	items ...*queuestore.Item,
 ) {
-	err := persistence.WithTransaction(
+	_, err := persistence.WithTransaction(
 		ctx,
 		ds,
 		func(tx persistence.ManagedTransaction) error {
@@ -40,7 +40,7 @@ func removeMessages(
 	ds persistence.DataStore,
 	items ...*queuestore.Item,
 ) {
-	err := persistence.WithTransaction(
+	_, err := persistence.WithTransaction(
 		ctx,
 		ds,
 		func(tx persistence.ManagedTransaction) error {

--- a/persistence/internal/providertest/transaction.go
+++ b/persistence/internal/providertest/transaction.go
@@ -146,5 +146,13 @@ func declareTransactionTests(
 				})
 			})
 		})
+
+		ginkgo.When("no operations occurred within the transaction", func() {
+			ginkgo.It("returns an empty transaction result", func() {
+				result, err := transaction.Commit(*ctx)
+				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+				gomega.Expect(result).To(gomega.Equal(&persistence.TransactionResult{}))
+			})
+		})
 	})
 }

--- a/persistence/internal/providertest/transaction.go
+++ b/persistence/internal/providertest/transaction.go
@@ -51,7 +51,7 @@ func declareTransactionTests(
 
 		ginkgo.When("the transaction has been committed", func() {
 			ginkgo.BeforeEach(func() {
-				err := transaction.Commit(*ctx)
+				_, err := transaction.Commit(*ctx)
 				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 			})
 
@@ -85,14 +85,14 @@ func declareTransactionTests(
 
 			ginkgo.Describe("func Commit()", func() {
 				ginkgo.It("returns an error", func() {
-					err := transaction.Commit(*ctx)
+					_, err := transaction.Commit(*ctx)
 					gomega.Expect(err).To(gomega.Equal(persistence.ErrTransactionClosed))
 				})
 			})
 
 			ginkgo.Describe("func Rollback()", func() {
 				ginkgo.It("returns an error", func() {
-					err := transaction.Commit(*ctx)
+					_, err := transaction.Commit(*ctx)
 					gomega.Expect(err).To(gomega.Equal(persistence.ErrTransactionClosed))
 				})
 			})
@@ -134,14 +134,14 @@ func declareTransactionTests(
 
 			ginkgo.Describe("func Commit()", func() {
 				ginkgo.It("returns an error", func() {
-					err := transaction.Commit(*ctx)
+					_, err := transaction.Commit(*ctx)
 					gomega.Expect(err).To(gomega.Equal(persistence.ErrTransactionClosed))
 				})
 			})
 
 			ginkgo.Describe("func Rollback()", func() {
 				ginkgo.It("returns an error", func() {
-					err := transaction.Commit(*ctx)
+					_, err := transaction.Commit(*ctx)
 					gomega.Expect(err).To(gomega.Equal(persistence.ErrTransactionClosed))
 				})
 			})

--- a/persistence/internal/providertest/transaction.go
+++ b/persistence/internal/providertest/transaction.go
@@ -151,7 +151,7 @@ func declareTransactionTests(
 			ginkgo.It("returns an empty transaction result", func() {
 				result, err := transaction.Commit(*ctx)
 				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
-				gomega.Expect(result).To(gomega.Equal(&persistence.TransactionResult{}))
+				gomega.Expect(result).To(gomega.Equal(persistence.TransactionResult{}))
 			})
 		})
 	})

--- a/persistence/provider/boltdb/eventstore.go
+++ b/persistence/provider/boltdb/eventstore.go
@@ -66,8 +66,8 @@ func (t *transaction) SaveEvent(
 		marshalUint64(o+1),
 	)
 
-	t.result.EventItems = append(
-		t.result.EventItems,
+	t.result.EventStoreItems = append(
+		t.result.EventStoreItems,
 		&eventstore.Item{
 			Offset:   o,
 			Envelope: env,

--- a/persistence/provider/boltdb/eventstore.go
+++ b/persistence/provider/boltdb/eventstore.go
@@ -66,6 +66,14 @@ func (t *transaction) SaveEvent(
 		marshalUint64(o+1),
 	)
 
+	t.result.EventItems = append(
+		t.result.EventItems,
+		&eventstore.Item{
+			Offset:   o,
+			Envelope: env,
+		},
+	)
+
 	return o, nil
 }
 

--- a/persistence/provider/boltdb/transaction.go
+++ b/persistence/provider/boltdb/transaction.go
@@ -34,7 +34,7 @@ func (t *transaction) Commit(
 		return &t.result, t.actual.Commit()
 	}
 
-	return t.result, nil
+	return &t.result, nil
 }
 
 // Rollback aborts the transaction.

--- a/persistence/provider/boltdb/transaction.go
+++ b/persistence/provider/boltdb/transaction.go
@@ -11,7 +11,7 @@ import (
 // data stores.
 type transaction struct {
 	ds     *dataStore
-	result *persistence.TransactionResult
+	result persistence.TransactionResult
 	appKey []byte
 	actual *bbolt.Tx
 }
@@ -31,10 +31,7 @@ func (t *transaction) Commit(
 	}
 
 	if t.actual != nil {
-		if err := t.actual.Commit(); err != nil {
-			return nil, err
-		}
-
+		return &t.result, t.actual.Commit()
 	}
 
 	return t.result, nil
@@ -74,8 +71,6 @@ func (t *transaction) begin(ctx context.Context) error {
 		t.actual = t.ds.db.Begin(ctx)
 	}
 
-	t.result = &persistence.TransactionResult{}
-
 	return nil
 }
 
@@ -89,5 +84,4 @@ func (t *transaction) end() {
 	}
 
 	t.ds = nil
-	t.result = nil
 }

--- a/persistence/provider/boltdb/transaction.go
+++ b/persistence/provider/boltdb/transaction.go
@@ -19,22 +19,23 @@ type transaction struct {
 // Commit applies the changes from the transaction.
 func (t *transaction) Commit(
 	ctx context.Context,
-) (*persistence.TransactionResult, error) {
+) (persistence.TransactionResult, error) {
 	defer t.end()
 
 	if t.ds == nil {
-		return nil, persistence.ErrTransactionClosed
+		return persistence.TransactionResult{},
+			persistence.ErrTransactionClosed
 	}
 
 	if err := t.ds.checkOpen(); err != nil {
-		return nil, err
+		return persistence.TransactionResult{}, err
 	}
 
 	if t.actual != nil {
-		return &t.result, t.actual.Commit()
+		return t.result, t.actual.Commit()
 	}
 
-	return &t.result, nil
+	return t.result, nil
 }
 
 // Rollback aborts the transaction.

--- a/persistence/provider/memory/eventstore.go
+++ b/persistence/provider/memory/eventstore.go
@@ -5,7 +5,6 @@ import (
 	"math"
 
 	"github.com/dogmatiq/infix/draftspecs/envelopespec"
-	"github.com/dogmatiq/infix/persistence"
 	"github.com/dogmatiq/infix/persistence/subsystem/eventstore"
 )
 
@@ -20,7 +19,7 @@ func (t *transaction) SaveEvent(
 		return 0, err
 	}
 
-	return t.event.stageSave(&t.ds.db.event, t.result, env), nil
+	return t.event.stageSave(&t.ds.db.event, env), nil
 }
 
 // eventStoreRepository is an implementation of eventstore.Repository that
@@ -112,7 +111,6 @@ type eventStoreChangeSet struct {
 // stageSave adds a "SaveEvent" operation to the change-set.
 func (cs *eventStoreChangeSet) stageSave(
 	db *eventStoreDatabase,
-	result *persistence.TransactionResult,
 	env *envelopespec.Envelope,
 ) uint64 {
 	// Find the offset for the new event based on what's already in the database
@@ -127,8 +125,6 @@ func (cs *eventStoreChangeSet) stageSave(
 	}
 
 	cs.items = append(cs.items, item)
-
-	result.EventItems = append(result.EventItems, item)
 
 	return next
 }

--- a/persistence/provider/memory/eventstore.go
+++ b/persistence/provider/memory/eventstore.go
@@ -5,6 +5,7 @@ import (
 	"math"
 
 	"github.com/dogmatiq/infix/draftspecs/envelopespec"
+	"github.com/dogmatiq/infix/persistence"
 	"github.com/dogmatiq/infix/persistence/subsystem/eventstore"
 )
 
@@ -19,7 +20,11 @@ func (t *transaction) SaveEvent(
 		return 0, err
 	}
 
-	return t.event.stageSave(&t.ds.db.event, env), nil
+	t.result.EventItems = append(
+		t.result.EventItems,
+	)
+
+	return t.event.stageSave(&t.ds.db.event, t.result, env), nil
 }
 
 // eventStoreRepository is an implementation of eventstore.Repository that
@@ -111,6 +116,7 @@ type eventStoreChangeSet struct {
 // stageSave adds a "SaveEvent" operation to the change-set.
 func (cs *eventStoreChangeSet) stageSave(
 	db *eventStoreDatabase,
+	result *persistence.TransactionResult,
 	env *envelopespec.Envelope,
 ) uint64 {
 	// Find the offset for the new event based on what's already in the database
@@ -125,6 +131,8 @@ func (cs *eventStoreChangeSet) stageSave(
 	}
 
 	cs.items = append(cs.items, item)
+
+	result.EventItems = append(result.EventItems, item)
 
 	return next
 }

--- a/persistence/provider/memory/eventstore.go
+++ b/persistence/provider/memory/eventstore.go
@@ -20,10 +20,6 @@ func (t *transaction) SaveEvent(
 		return 0, err
 	}
 
-	t.result.EventItems = append(
-		t.result.EventItems,
-	)
-
 	return t.event.stageSave(&t.ds.db.event, t.result, env), nil
 }
 

--- a/persistence/provider/memory/transaction.go
+++ b/persistence/provider/memory/transaction.go
@@ -32,7 +32,7 @@ func (t *transaction) Commit(
 	}
 
 	if !t.hasLock {
-		return nil, nil
+		return &persistence.TransactionResult{}, nil
 	}
 
 	t.ds.db.aggregate.apply(&t.aggregate)

--- a/persistence/provider/memory/transaction.go
+++ b/persistence/provider/memory/transaction.go
@@ -15,7 +15,6 @@ type transaction struct {
 	event     eventStoreChangeSet
 	offset    offsetStoreChangeSet
 	queue     queueStoreChangeSet
-	result    *persistence.TransactionResult
 }
 
 // Commit applies the changes from the transaction.
@@ -41,7 +40,9 @@ func (t *transaction) Commit(
 	t.ds.db.offset.apply(&t.offset)
 	t.ds.db.queue.apply(&t.queue)
 
-	return t.result, nil
+	return &persistence.TransactionResult{
+		EventItems: t.event.items,
+	}, nil
 }
 
 // Rollback aborts the transaction.
@@ -74,7 +75,6 @@ func (t *transaction) begin(ctx context.Context) error {
 	}
 
 	t.hasLock = true
-	t.result = &persistence.TransactionResult{}
 
 	return nil
 }
@@ -87,5 +87,4 @@ func (t *transaction) end() {
 	}
 
 	t.ds = nil
-	t.result = nil
 }

--- a/persistence/provider/memory/transaction.go
+++ b/persistence/provider/memory/transaction.go
@@ -41,7 +41,7 @@ func (t *transaction) Commit(
 	t.ds.db.queue.apply(&t.queue)
 
 	return &persistence.TransactionResult{
-		EventItems: t.event.items,
+		EventStoreItems: t.event.items,
 	}, nil
 }
 

--- a/persistence/provider/sql/eventstore.go
+++ b/persistence/provider/sql/eventstore.go
@@ -115,8 +115,8 @@ func (t *transaction) SaveEvent(
 		return 0, err
 	}
 
-	t.result.EventItems = append(
-		t.result.EventItems,
+	t.result.EventStoreItems = append(
+		t.result.EventStoreItems,
 		&eventstore.Item{
 			Offset:   next,
 			Envelope: env,

--- a/persistence/provider/sql/eventstore.go
+++ b/persistence/provider/sql/eventstore.go
@@ -106,12 +106,24 @@ func (t *transaction) SaveEvent(
 
 	next--
 
-	return next, t.ds.driver.InsertEvent(
+	if err := t.ds.driver.InsertEvent(
 		ctx,
 		t.actual,
 		next,
 		env,
+	); err != nil {
+		return 0, err
+	}
+
+	t.result.EventItems = append(
+		t.result.EventItems,
+		&eventstore.Item{
+			Offset:   next,
+			Envelope: env,
+		},
 	)
+
+	return next, nil
 }
 
 // eventStoreRepository is an implementation of eventstore.Repository that

--- a/persistence/provider/sql/transaction.go
+++ b/persistence/provider/sql/transaction.go
@@ -12,7 +12,7 @@ import (
 type transaction struct {
 	ds     *dataStore
 	actual *sql.Tx
-	result *persistence.TransactionResult
+	result persistence.TransactionResult
 }
 
 // Commit applies the changes from the transaction.
@@ -30,9 +30,7 @@ func (t *transaction) Commit(
 	}
 
 	if t.actual != nil {
-		if err := t.actual.Commit(); err != nil {
-			return nil, err
-		}
+		return &t.result, t.actual.Commit()
 	}
 
 	return t.result, nil

--- a/persistence/provider/sql/transaction.go
+++ b/persistence/provider/sql/transaction.go
@@ -18,22 +18,23 @@ type transaction struct {
 // Commit applies the changes from the transaction.
 func (t *transaction) Commit(
 	ctx context.Context,
-) (*persistence.TransactionResult, error) {
+) (persistence.TransactionResult, error) {
 	defer t.end()
 
 	if t.ds == nil {
-		return nil, persistence.ErrTransactionClosed
+		return persistence.TransactionResult{},
+			persistence.ErrTransactionClosed
 	}
 
 	if err := t.ds.checkOpen(); err != nil {
-		return nil, err
+		return persistence.TransactionResult{}, err
 	}
 
 	if t.actual != nil {
-		return &t.result, t.actual.Commit()
+		return t.result, t.actual.Commit()
 	}
 
-	return &t.result, nil
+	return t.result, nil
 }
 
 // Rollback aborts the transaction.

--- a/persistence/provider/sql/transaction.go
+++ b/persistence/provider/sql/transaction.go
@@ -33,7 +33,7 @@ func (t *transaction) Commit(
 		return &t.result, t.actual.Commit()
 	}
 
-	return t.result, nil
+	return &t.result, nil
 }
 
 // Rollback aborts the transaction.
@@ -66,8 +66,6 @@ func (t *transaction) begin(ctx context.Context) error {
 		t.actual, err = t.ds.driver.Begin(ctx, t.ds.db)
 	}
 
-	t.result = &persistence.TransactionResult{}
-
 	return err
 }
 
@@ -79,5 +77,4 @@ func (t *transaction) end() {
 	}
 
 	t.ds = nil
-	t.result = nil
 }

--- a/persistence/transaction.go
+++ b/persistence/transaction.go
@@ -29,10 +29,9 @@ type Transaction interface {
 	Rollback() error
 }
 
-// TransactionResult is the result returned by Transaction.Commit() method.
+// TransactionResult contains information about a successfully committed transaction.
 type TransactionResult struct {
-	// EventItems is the slice of eventstore.Item persisted within the boundary
-	// of the transaction.
+	// EventItems contains the events persisted within the transaction.
 	EventItems []*eventstore.Item
 }
 

--- a/persistence/transaction.go
+++ b/persistence/transaction.go
@@ -23,7 +23,7 @@ type Transaction interface {
 	offsetstore.Transaction
 
 	// Commit applies the changes from the transaction.
-	Commit(ctx context.Context) (*TransactionResult, error)
+	Commit(ctx context.Context) (TransactionResult, error)
 
 	// Rollback aborts the transaction.
 	Rollback() error
@@ -52,15 +52,15 @@ func WithTransaction(
 	ctx context.Context,
 	ds DataStore,
 	fn func(ManagedTransaction) error,
-) (*TransactionResult, error) {
+) (TransactionResult, error) {
 	tx, err := ds.Begin(ctx)
 	if err != nil {
-		return nil, err
+		return TransactionResult{}, err
 	}
 	defer tx.Rollback()
 
 	if err := fn(tx); err != nil {
-		return nil, err
+		return TransactionResult{}, err
 	}
 
 	return tx.Commit(ctx)

--- a/persistence/transaction.go
+++ b/persistence/transaction.go
@@ -31,8 +31,8 @@ type Transaction interface {
 
 // TransactionResult contains information about a successfully committed transaction.
 type TransactionResult struct {
-	// EventItems contains the events persisted within the transaction.
-	EventItems []*eventstore.Item
+	// EventStoreItems contains the events persisted within the transaction.
+	EventStoreItems []*eventstore.Item
 }
 
 // ManagedTransaction is a Transaction that can not be commit or rolled-back

--- a/persistence/transaction_test.go
+++ b/persistence/transaction_test.go
@@ -9,7 +9,9 @@ import (
 	. "github.com/dogmatiq/infix/fixtures"
 	. "github.com/dogmatiq/infix/persistence"
 	"github.com/dogmatiq/infix/persistence/provider/memory"
+	"github.com/dogmatiq/infix/persistence/subsystem/eventstore"
 	"github.com/dogmatiq/infix/persistence/subsystem/queuestore"
+	. "github.com/jmalloc/gomegax"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -43,7 +45,7 @@ var _ = Describe("func WithTransaction", func() {
 	It("commits the transaction if fn returns nil", func() {
 		env := NewEnvelope("<id>", MessageA1)
 
-		err := WithTransaction(
+		_, err := WithTransaction(
 			ctx,
 			dataStore,
 			func(tx ManagedTransaction) error {
@@ -63,10 +65,61 @@ var _ = Describe("func WithTransaction", func() {
 		Expect(items).NotTo(BeEmpty())
 	})
 
+	It("returns the transaction result", func() {
+		env1 := NewEnvelope("<id-1>", MessageA1)
+		env2 := NewEnvelope("<id-2>", MessageA2)
+		env3 := NewEnvelope("<id-3>", MessageA3)
+
+		result, err := WithTransaction(
+			ctx,
+			dataStore,
+			func(tx ManagedTransaction) error {
+				if _, err := tx.SaveEvent(
+					ctx,
+					env1,
+				); err != nil {
+					return err
+				}
+
+				if _, err := tx.SaveEvent(
+					ctx,
+					env2,
+				); err != nil {
+					return err
+				}
+
+				_, err := tx.SaveEvent(
+					ctx,
+					env3,
+				)
+				return err
+			},
+		)
+
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(result.EventItems).NotTo(BeEmpty())
+		Expect(result.EventItems).To(
+			EqualX([]*eventstore.Item{
+				{
+					Offset:   0,
+					Envelope: env1,
+				},
+				{
+					Offset:   1,
+					Envelope: env2,
+				},
+				{
+					Offset:   2,
+					Envelope: env3,
+				},
+			}),
+		)
+	})
+
 	It("rolls the transaction back if fn returns an error", func() {
 		env := NewEnvelope("<id>", MessageA1)
 
-		err := WithTransaction(
+		_, err := WithTransaction(
 			ctx,
 			dataStore,
 			func(tx ManagedTransaction) error {
@@ -92,7 +145,7 @@ var _ = Describe("func WithTransaction", func() {
 	It("returns an error if the transaction can not be begun", func() {
 		dataStore.Close()
 
-		err := WithTransaction(
+		_, err := WithTransaction(
 			ctx,
 			dataStore,
 			func(ManagedTransaction) error {

--- a/persistence/transaction_test.go
+++ b/persistence/transaction_test.go
@@ -65,7 +65,7 @@ var _ = Describe("func WithTransaction", func() {
 		Expect(items).NotTo(BeEmpty())
 	})
 
-	It("returns the transaction result", func() {
+	It("includes event store items in the transaction result", func() {
 		env1 := NewEnvelope("<id-1>", MessageA1)
 		env2 := NewEnvelope("<id-2>", MessageA2)
 		env3 := NewEnvelope("<id-3>", MessageA3)

--- a/persistence/transaction_test.go
+++ b/persistence/transaction_test.go
@@ -97,8 +97,8 @@ var _ = Describe("func WithTransaction", func() {
 		)
 
 		Expect(err).ShouldNot(HaveOccurred())
-		Expect(result.EventItems).NotTo(BeEmpty())
-		Expect(result.EventItems).To(
+		Expect(result.EventStoreItems).NotTo(BeEmpty())
+		Expect(result.EventStoreItems).To(
 			EqualX([]*eventstore.Item{
 				{
 					Offset:   0,

--- a/pipeline/queue_test.go
+++ b/pipeline/queue_test.go
@@ -45,7 +45,7 @@ var _ = Describe("type QueueSource", func() {
 			Envelope:      p.Envelope,
 		}
 
-		err := persistence.WithTransaction(
+		_, err := persistence.WithTransaction(
 			ctx,
 			dataStore,
 			func(tx persistence.ManagedTransaction) error {
@@ -140,7 +140,7 @@ var _ = Describe("func TrackWithQueue()", func() {
 			Envelope:      pcl.Envelope,
 		}
 
-		err := persistence.WithTransaction(
+		_, err := persistence.WithTransaction(
 			ctx,
 			dataStore,
 			func(tx persistence.ManagedTransaction) error {

--- a/queue/executor.go
+++ b/queue/executor.go
@@ -25,7 +25,7 @@ func (x *CommandExecutor) ExecuteCommand(ctx context.Context, m dogma.Message) e
 		Envelope:      p.Envelope,
 	}
 
-	if err := persistence.WithTransaction(
+	if _, err := persistence.WithTransaction(
 		ctx,
 		x.Queue.DataStore,
 		func(tx persistence.ManagedTransaction) error {

--- a/queue/queue_test.go
+++ b/queue/queue_test.go
@@ -35,7 +35,7 @@ func push(
 		Envelope:      p.Envelope,
 	}
 
-	err := persistence.WithTransaction(
+	_, err := persistence.WithTransaction(
 		ctx,
 		q.DataStore,
 		func(tx persistence.ManagedTransaction) error {
@@ -194,7 +194,7 @@ var _ = Describe("type Queue", func() {
 						},
 					}
 
-					err := persistence.WithTransaction(
+					_, err := persistence.WithTransaction(
 						ctx,
 						dataStore,
 						func(tx persistence.ManagedTransaction) error {

--- a/queue/request.go
+++ b/queue/request.go
@@ -82,7 +82,7 @@ func (r *Request) Ack(ctx context.Context) error {
 		return err
 	}
 
-	if err := r.tx.Commit(ctx); err != nil {
+	if _, err := r.tx.Commit(ctx); err != nil {
 		return err
 	}
 
@@ -107,7 +107,7 @@ func (r *Request) Nack(ctx context.Context, n time.Time) error {
 	r.elem.item.FailureCount++
 	r.elem.item.NextAttemptAt = n
 
-	if err := persistence.WithTransaction(
+	if _, err := persistence.WithTransaction(
 		ctx,
 		r.queue.DataStore,
 		func(tx persistence.ManagedTransaction) error {

--- a/queue/request_test.go
+++ b/queue/request_test.go
@@ -225,8 +225,10 @@ var _ = Describe("type Request", func() {
 				tx, err := req.Tx(ctx)
 				Expect(err).ShouldNot(HaveOccurred())
 
-				tx.(*TransactionStub).CommitFunc = func(context.Context) error {
-					return errors.New("<error>")
+				tx.(*TransactionStub).CommitFunc = func(
+					context.Context,
+				) (*persistence.TransactionResult, error) {
+					return nil, errors.New("<error>")
 				}
 
 				err = req.Ack(ctx)

--- a/queue/request_test.go
+++ b/queue/request_test.go
@@ -227,8 +227,8 @@ var _ = Describe("type Request", func() {
 
 				tx.(*TransactionStub).CommitFunc = func(
 					context.Context,
-				) (*persistence.TransactionResult, error) {
-					return nil, errors.New("<error>")
+				) (persistence.TransactionResult, error) {
+					return persistence.TransactionResult{}, errors.New("<error>")
 				}
 
 				err = req.Ack(ctx)


### PR DESCRIPTION
This PR adds `persistence.TransactionResult` type returned by `persistence.Transaction.Commit()` method. This type is the container for all committed event for the committed event and queue items that looks like the following:
```go
// TransactionResult is the result returned by Transaction.Commit() method.
type TransactionResult struct {
	EventItems []*eventstore.Item
	QueueItems []*queuestore.Item
}
```