### PR TITLE
Avoid unmarshaling messages in the network server.

### DIFF
--- a/eventstream/networkstream/marshaler.go
+++ b/eventstream/networkstream/marshaler.go
@@ -1,0 +1,18 @@
+package networkstream
+
+import (
+	"github.com/dogmatiq/marshalkit"
+)
+
+// NoopUnmarshaler is a marshalkit.Marshaler decorator that always always
+// returns a nil result from Unmarshal().
+//
+// It is a simple optimization for the networkstream server that prevents
+// unnecessary unmarshaling of messages that are served in their marshaled-form.
+type NoopUnmarshaler struct {
+	marshalkit.Marshaler
+}
+
+func (NoopUnmarshaler) Unmarshal(marshalkit.Packet) (interface{}, error) {
+	return nil, nil
+}

--- a/eventstream/networkstream/marshaler_test.go
+++ b/eventstream/networkstream/marshaler_test.go
@@ -1,0 +1,18 @@
+package networkstream_test
+
+import (
+	. "github.com/dogmatiq/infix/eventstream/networkstream"
+	"github.com/dogmatiq/marshalkit"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("type NoopUnmarshaler", func() {
+	Describe("func Unmarshal()", func() {
+		It("returns nil", func() {
+			v, err := NoopUnmarshaler{}.Unmarshal(marshalkit.Packet{})
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(v).To(BeNil())
+		})
+	})
+})


### PR DESCRIPTION
Fixes #74 - last part!

This PR adds a `NoopUnmarshaler` which decorates a `marshalkit.Marshaler` in order to make the `Unmarshal()` method do nothing.

It's used to construct a `persistedstream.Stream` instance that can be used by `networkstream.server` to get events to serve without the overhead of unmarshaling them.  The unmarshaling is useless is because all the network server does is sends the marshaled-form in a gRPC response.