### PR TITLE
Add LoadEventsForAggregate() method.

### DIFF
--- a/fixtures/eventstore.go
+++ b/fixtures/eventstore.go
@@ -11,7 +11,26 @@ import (
 type EventStoreRepositoryStub struct {
 	eventstore.Repository
 
-	QueryEventsFunc func(context.Context, eventstore.Query) (eventstore.Result, error)
+	QueryEventsFunc            func(context.Context, eventstore.Query) (eventstore.Result, error)
+	LoadEventsForAggregateFunc func(context.Context, string, string, uint64) (eventstore.Result, error)
+}
+
+// LoadEventsForAggregate loads the events for the aggregate with the given
+// key, id, and revision.
+func (r *EventStoreRepositoryStub) LoadEventsForAggregate(
+	ctx context.Context,
+	hk, id string,
+	rev uint64,
+) (eventstore.Result, error) {
+	if r.LoadEventsForAggregateFunc != nil {
+		return r.LoadEventsForAggregateFunc(ctx, hk, id, rev)
+	}
+
+	if r.Repository != nil {
+		return r.Repository.LoadEventsForAggregate(ctx, hk, id, rev)
+	}
+
+	return nil, nil
 }
 
 // QueryEvents queries events in the repository.

--- a/persistence/internal/providertest/eventstore/repository.go
+++ b/persistence/internal/providertest/eventstore/repository.go
@@ -184,7 +184,78 @@ func DeclareRepositoryTests(tc *common.TestContext) {
 				),
 			)
 
-			ginkgo.It("allows concurrent filtered consumers for the same application", func() {
+			ginkgo.It("does not return an error if events exist beyond the end offset", func() {
+				res, err := repository.QueryEvents(tc.Context, eventstore.Query{})
+				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+				defer res.Close()
+
+				saveEvents(
+					tc.Context,
+					dataStore,
+					item0.Envelope,
+					item1.Envelope,
+				)
+
+				// The implementation may or may not expose these newly
+				// appended events to the caller. We simply want to ensure
+				// that no error occurs.
+				_, _, err = res.Next(tc.Context)
+				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+			})
+		})
+
+		ginkgo.Describe("func LoadEventsForAggregate()", func() {
+			ginkgo.It("returns an empty result if the store is empty", func() {
+				items := loadEventsForAggregate(tc.Context, repository, "<aggregate>", "<instance-a>", 0)
+				gomega.Expect(items).To(gomega.BeEmpty())
+			})
+
+			ginkgo.It("it returns a result containing the events that match the aggregate instance", func() {
+				expected := []*eventstore.Item{item0, item3}
+				saveEvents(
+					tc.Context,
+					dataStore,
+					item0.Envelope,
+					item1.Envelope,
+					item2.Envelope,
+					item3.Envelope,
+					item4.Envelope,
+					item5.Envelope,
+				)
+
+				items := loadEventsForAggregate(tc.Context, repository, "<aggregate>", "<instance-a>", 1)
+
+				for i, item := range items {
+					expectItemToEqual(
+						item,
+						expected[i],
+						fmt.Sprintf("item at index #%d of slice", i),
+					)
+				}
+			})
+
+			ginkgo.It("does not return an error if events exist beyond the end offset", func() {
+				res, err := repository.LoadEventsForAggregate(tc.Context, "<aggregate>", "<instance-a>", 0)
+				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+				defer res.Close()
+
+				saveEvents(
+					tc.Context,
+					dataStore,
+					item0.Envelope,
+					item1.Envelope,
+				)
+
+				// The implementation may or may not expose these newly
+				// appended events to the caller. We simply want to ensure
+				// that no error occurs.
+				_, _, err = res.Next(tc.Context)
+				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+			})
+		})
+
+		ginkgo.Describe("func QueryEvents() and LoadEventsForAggregate()", func() {
+			ginkgo.It("allows concurrent consumers for the same application", func() {
 				saveEvents(
 					tc.Context,
 					dataStore,
@@ -204,38 +275,36 @@ func DeclareRepositoryTests(tc *common.TestContext) {
 
 				var g sync.WaitGroup
 
-				fn := func() {
+				fn1 := func() {
 					defer g.Done()
 					defer ginkgo.GinkgoRecover()
 					items := queryEvents(tc.Context, repository, q)
 					gomega.Expect(items).To(gomega.HaveLen(2))
 				}
 
+				fn2 := func() {
+					defer g.Done()
+					defer ginkgo.GinkgoRecover()
+					items := loadEventsForAggregate(
+						tc.Context,
+						repository,
+						"<aggregate>",
+						"<instance-a>",
+						1,
+					)
+					gomega.Expect(items).To(gomega.HaveLen(2))
+				}
+
 				g.Add(3)
-				go fn()
-				go fn()
-				go fn()
+				go fn1()
+				go fn2()
+				go fn1()
+				go fn2()
+				go fn1()
+				go fn2()
 				g.Wait()
 			})
 
-			ginkgo.It("does not return an error if events exist beyond the end offset", func() {
-				res, err := repository.QueryEvents(tc.Context, eventstore.Query{})
-				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
-				defer res.Close()
-
-				saveEvents(
-					tc.Context,
-					dataStore,
-					item0.Envelope,
-					item1.Envelope,
-				)
-
-				// The implementation may or may not expose these newly
-				// appended events to the caller. We simply want to ensure
-				// that no error occurs.
-				_, _, err = res.Next(tc.Context)
-				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
-			})
 		})
 
 		ginkgo.Describe("type eventstore.Result", func() {

--- a/persistence/internal/providertest/eventstore/repository.go
+++ b/persistence/internal/providertest/eventstore/repository.go
@@ -211,7 +211,9 @@ func DeclareRepositoryTests(tc *common.TestContext) {
 			})
 
 			ginkgo.It("it returns a result containing the events that match the aggregate instance", func() {
-				expected := []*eventstore.Item{item0, item3}
+				expectedA := []*eventstore.Item{item0, item2}
+				expectedB := []*eventstore.Item{item1, item3}
+
 				saveEvents(
 					tc.Context,
 					dataStore,
@@ -223,12 +225,22 @@ func DeclareRepositoryTests(tc *common.TestContext) {
 					item5.Envelope,
 				)
 
-				items := loadEventsForAggregate(tc.Context, repository, "<aggregate>", "<instance-a>", 1)
+				items := loadEventsForAggregate(tc.Context, repository, "<aggregate>", "<instance-a>", 0)
 
 				for i, item := range items {
 					expectItemToEqual(
 						item,
-						expected[i],
+						expectedA[i],
+						fmt.Sprintf("item at index #%d of slice", i),
+					)
+				}
+
+				items = loadEventsForAggregate(tc.Context, repository, "<aggregate>", "<instance-b>", 0)
+
+				for i, item := range items {
+					expectItemToEqual(
+						item,
+						expectedB[i],
 						fmt.Sprintf("item at index #%d of slice", i),
 					)
 				}
@@ -290,12 +302,12 @@ func DeclareRepositoryTests(tc *common.TestContext) {
 						repository,
 						"<aggregate>",
 						"<instance-a>",
-						1,
+						0,
 					)
 					gomega.Expect(items).To(gomega.HaveLen(2))
 				}
 
-				g.Add(3)
+				g.Add(6)
 				go fn1()
 				go fn2()
 				go fn1()

--- a/persistence/internal/providertest/eventstore/util.go
+++ b/persistence/internal/providertest/eventstore/util.go
@@ -77,3 +77,29 @@ func queryEvents(
 		items = append(items, i)
 	}
 }
+
+// loadEventsForAggregate loads the event items for the aggregate with the given
+// key, id, and revision.
+func loadEventsForAggregate(
+	ctx context.Context,
+	r eventstore.Repository,
+	hk, id string,
+	rev uint64,
+) []*eventstore.Item {
+	res, err := r.LoadEventsForAggregate(ctx, hk, id, rev)
+	gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+	defer res.Close()
+
+	var items []*eventstore.Item
+
+	for {
+		i, ok, err := res.Next(ctx)
+		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+
+		if !ok {
+			return items
+		}
+
+		items = append(items, i)
+	}
+}

--- a/persistence/provider/boltdb/eventstore.go
+++ b/persistence/provider/boltdb/eventstore.go
@@ -110,6 +110,16 @@ func (r *eventStoreRepository) NextEventOffset(
 	return next, err
 }
 
+// LoadEventsForAggregate loads the events for the aggregate with the given
+// key, id, and revision.
+func (r *eventStoreRepository) LoadEventsForAggregate(
+	ctx context.Context,
+	hk, id string,
+	rev uint64,
+) (eventstore.Result, error) {
+	panic("not implemented")
+}
+
 // QueryEvents queries events in the repository.
 func (r *eventStoreRepository) QueryEvents(
 	ctx context.Context,

--- a/persistence/provider/boltdb/eventstore.go
+++ b/persistence/provider/boltdb/eventstore.go
@@ -117,7 +117,15 @@ func (r *eventStoreRepository) LoadEventsForAggregate(
 	hk, id string,
 	rev uint64,
 ) (eventstore.Result, error) {
-	panic("not implemented")
+	return &eventStoreResult{
+		db:     r.db,
+		appKey: r.appKey,
+		query: eventstore.Query{
+			MinOffset:           rev,
+			AggregateHandlerKey: hk,
+			AggregateInstanceID: id,
+		},
+	}, nil
 }
 
 // QueryEvents queries events in the repository.

--- a/persistence/provider/memory/eventstore.go
+++ b/persistence/provider/memory/eventstore.go
@@ -42,6 +42,16 @@ func (r *eventStoreRepository) NextEventOffset(
 	return uint64(next), nil
 }
 
+// LoadEventsForAggregate loads the events for the aggregate with the given
+// key, id, and revision.
+func (r *eventStoreRepository) LoadEventsForAggregate(
+	ctx context.Context,
+	hk, id string,
+	rev uint64,
+) (eventstore.Result, error) {
+	panic("not implemented")
+}
+
 // QueryEvents queries events in the repository.
 func (r *eventStoreRepository) QueryEvents(
 	ctx context.Context,

--- a/persistence/provider/memory/eventstore.go
+++ b/persistence/provider/memory/eventstore.go
@@ -49,7 +49,14 @@ func (r *eventStoreRepository) LoadEventsForAggregate(
 	hk, id string,
 	rev uint64,
 ) (eventstore.Result, error) {
-	panic("not implemented")
+	return &eventStoreResult{
+		db: r.db,
+		query: eventstore.Query{
+			MinOffset:           rev,
+			AggregateHandlerKey: hk,
+			AggregateInstanceID: id,
+		},
+	}, nil
 }
 
 // QueryEvents queries events in the repository.

--- a/persistence/provider/sql/eventstore.go
+++ b/persistence/provider/sql/eventstore.go
@@ -152,7 +152,11 @@ func (r *eventStoreRepository) LoadEventsForAggregate(
 	hk, id string,
 	rev uint64,
 ) (eventstore.Result, error) {
-	panic("not implemented")
+	return r.QueryEvents(ctx, eventstore.Query{
+		MinOffset:           rev,
+		AggregateHandlerKey: hk,
+		AggregateInstanceID: id,
+	})
 }
 
 // QueryEvents queries events in the repository.

--- a/persistence/provider/sql/eventstore.go
+++ b/persistence/provider/sql/eventstore.go
@@ -145,6 +145,16 @@ func (r *eventStoreRepository) NextEventOffset(
 	)
 }
 
+// LoadEventsForAggregate loads the events for the aggregate with the given
+// key, id, and revision.
+func (r *eventStoreRepository) LoadEventsForAggregate(
+	ctx context.Context,
+	hk, id string,
+	rev uint64,
+) (eventstore.Result, error) {
+	panic("not implemented")
+}
+
 // QueryEvents queries events in the repository.
 func (r *eventStoreRepository) QueryEvents(
 	ctx context.Context,

--- a/persistence/subsystem/eventstore/repository.go
+++ b/persistence/subsystem/eventstore/repository.go
@@ -9,6 +9,14 @@ type Repository interface {
 	// NextEventOffset returns the next "unused" offset within the store.
 	NextEventOffset(ctx context.Context) (uint64, error)
 
+	// LoadEventsForAggregate loads the events for the aggregate with the given
+	// key, id, and revision.
+	LoadEventsForAggregate(
+		ctx context.Context,
+		hk, id string,
+		rev uint64,
+	) (Result, error)
+
 	// QueryEvents queries events in the repository.
 	QueryEvents(ctx context.Context, q Query) (Result, error)
 }


### PR DESCRIPTION
This PR partially addressed #220 and adds `LoadEventsForAggregate()` to the `evenstore.Repository` type.