### PR TITLE
Add LoadEventsBySource() method in eventstore.Repository

### DIFF
--- a/fixtures/eventstore.go
+++ b/fixtures/eventstore.go
@@ -11,22 +11,22 @@ import (
 type EventStoreRepositoryStub struct {
 	eventstore.Repository
 
-	QueryEventsFunc            func(context.Context, eventstore.Query) (eventstore.Result, error)
-	LoadEventsForAggregateFunc func(context.Context, string, string, string) (eventstore.Result, error)
+	QueryEventsFunc        func(context.Context, eventstore.Query) (eventstore.Result, error)
+	LoadEventsBySourceFunc func(context.Context, string, string, string) (eventstore.Result, error)
 }
 
-// LoadEventsForAggregate loads the events for the aggregate with the given
-// key and id.
-func (r *EventStoreRepositoryStub) LoadEventsForAggregate(
+// LoadEventsBySource loads the events produced by the specified source with
+// the given handler key and id.
+func (r *EventStoreRepositoryStub) LoadEventsBySource(
 	ctx context.Context,
 	hk, id, d string,
 ) (eventstore.Result, error) {
-	if r.LoadEventsForAggregateFunc != nil {
-		return r.LoadEventsForAggregateFunc(ctx, hk, id, d)
+	if r.LoadEventsBySourceFunc != nil {
+		return r.LoadEventsBySourceFunc(ctx, hk, id, d)
 	}
 
 	if r.Repository != nil {
-		return r.Repository.LoadEventsForAggregate(ctx, hk, id, d)
+		return r.Repository.LoadEventsBySource(ctx, hk, id, d)
 	}
 
 	return nil, nil

--- a/fixtures/eventstore.go
+++ b/fixtures/eventstore.go
@@ -11,7 +11,25 @@ import (
 type EventStoreRepositoryStub struct {
 	eventstore.Repository
 
-	QueryEventsFunc func(context.Context, eventstore.Query) (eventstore.Result, error)
+	QueryEventsFunc            func(context.Context, eventstore.Query) (eventstore.Result, error)
+	LoadEventsForAggregateFunc func(context.Context, string, string, string) (eventstore.Result, error)
+}
+
+// LoadEventsForAggregate loads the events for the aggregate with the given
+// key and id.
+func (r *EventStoreRepositoryStub) LoadEventsForAggregate(
+	ctx context.Context,
+	hk, id, d string,
+) (eventstore.Result, error) {
+	if r.LoadEventsForAggregateFunc != nil {
+		return r.LoadEventsForAggregateFunc(ctx, hk, id, d)
+	}
+
+	if r.Repository != nil {
+		return r.Repository.LoadEventsForAggregate(ctx, hk, id, d)
+	}
+
+	return nil, nil
 }
 
 // QueryEvents queries events in the repository.

--- a/fixtures/eventstore.go
+++ b/fixtures/eventstore.go
@@ -15,8 +15,7 @@ type EventStoreRepositoryStub struct {
 	LoadEventsBySourceFunc func(context.Context, string, string, string) (eventstore.Result, error)
 }
 
-// LoadEventsBySource loads the events produced by the specified source with
-// the given handler key and id.
+// LoadEventsBySource loads the events produced by a specific handler.
 func (r *EventStoreRepositoryStub) LoadEventsBySource(
 	ctx context.Context,
 	hk, id, d string,

--- a/persistence/internal/providertest/eventstore/repository.go
+++ b/persistence/internal/providertest/eventstore/repository.go
@@ -204,9 +204,9 @@ func DeclareRepositoryTests(tc *common.TestContext) {
 			})
 		})
 
-		ginkgo.Describe("func LoadEventsForAggregate()", func() {
+		ginkgo.Describe("func LoadEventsBySource()", func() {
 			ginkgo.It("returns an empty result if the store is empty", func() {
-				items := loadEventsForAggregate(tc.Context, repository, "<aggregate>", "<instance-a>", "")
+				items := loadEventsBySource(tc.Context, repository, "<aggregate>", "<instance-a>", "")
 				gomega.Expect(items).To(gomega.BeEmpty())
 			})
 
@@ -225,7 +225,7 @@ func DeclareRepositoryTests(tc *common.TestContext) {
 					item5.Envelope,
 				)
 
-				items := loadEventsForAggregate(
+				items := loadEventsBySource(
 					tc.Context,
 					repository,
 					"<aggregate>",
@@ -241,7 +241,7 @@ func DeclareRepositoryTests(tc *common.TestContext) {
 					)
 				}
 
-				items = loadEventsForAggregate(
+				items = loadEventsBySource(
 					tc.Context,
 					repository,
 					"<aggregate>",
@@ -273,7 +273,7 @@ func DeclareRepositoryTests(tc *common.TestContext) {
 					item5.Envelope,
 				)
 
-				items := loadEventsForAggregate(
+				items := loadEventsBySource(
 					tc.Context,
 					repository,
 					"<aggregate>",
@@ -289,7 +289,7 @@ func DeclareRepositoryTests(tc *common.TestContext) {
 					)
 				}
 
-				items = loadEventsForAggregate(
+				items = loadEventsBySource(
 					tc.Context,
 					repository,
 					"<aggregate>",
@@ -307,7 +307,7 @@ func DeclareRepositoryTests(tc *common.TestContext) {
 			})
 
 			ginkgo.It("does not return an error if events exist beyond the end offset", func() {
-				res, err := repository.LoadEventsForAggregate(tc.Context, "<aggregate>", "<instance-a>", "")
+				res, err := repository.LoadEventsBySource(tc.Context, "<aggregate>", "<instance-a>", "")
 				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 				defer res.Close()
 
@@ -326,7 +326,7 @@ func DeclareRepositoryTests(tc *common.TestContext) {
 			})
 		})
 
-		ginkgo.Describe("func QueryEvents() and LoadEventsForAggregate()", func() {
+		ginkgo.Describe("func QueryEvents() and loadEventsBySource()", func() {
 			ginkgo.It("allows concurrent consumers for the same application", func() {
 				saveEvents(
 					tc.Context,
@@ -357,7 +357,7 @@ func DeclareRepositoryTests(tc *common.TestContext) {
 				fn2 := func() {
 					defer g.Done()
 					defer ginkgo.GinkgoRecover()
-					items := loadEventsForAggregate(
+					items := loadEventsBySource(
 						tc.Context,
 						repository,
 						"<aggregate>",

--- a/persistence/internal/providertest/eventstore/repository.go
+++ b/persistence/internal/providertest/eventstore/repository.go
@@ -210,7 +210,7 @@ func DeclareRepositoryTests(tc *common.TestContext) {
 				gomega.Expect(items).To(gomega.BeEmpty())
 			})
 
-			ginkgo.It("it returns a result containing the events that match the aggregate instance", func() {
+			ginkgo.It("returns a result containing the events that match the aggregate instance", func() {
 				expectedA := []*eventstore.Item{item0, item2}
 				expectedB := []*eventstore.Item{item1, item3}
 
@@ -230,7 +230,7 @@ func DeclareRepositoryTests(tc *common.TestContext) {
 					repository,
 					"<aggregate>",
 					"<instance-a>",
-					item0.Envelope.MetaData.MessageId,
+					"",
 				)
 
 				for i, item := range items {
@@ -246,7 +246,55 @@ func DeclareRepositoryTests(tc *common.TestContext) {
 					repository,
 					"<aggregate>",
 					"<instance-b>",
-					item1.Envelope.MetaData.MessageId,
+					"",
+				)
+
+				for i, item := range items {
+					expectItemToEqual(
+						item,
+						expectedB[i],
+						fmt.Sprintf("item at index #%d of slice", i),
+					)
+				}
+			})
+
+			ginkgo.It("matches the events for the aggregate only from the given message id, if specified ", func() {
+				expectedA := []*eventstore.Item{item2}
+				expectedB := []*eventstore.Item{item3}
+
+				saveEvents(
+					tc.Context,
+					dataStore,
+					item0.Envelope,
+					item1.Envelope,
+					item2.Envelope,
+					item3.Envelope,
+					item4.Envelope,
+					item5.Envelope,
+				)
+
+				items := loadEventsForAggregate(
+					tc.Context,
+					repository,
+					"<aggregate>",
+					"<instance-a>",
+					item2.Envelope.MetaData.MessageId,
+				)
+
+				for i, item := range items {
+					expectItemToEqual(
+						item,
+						expectedA[i],
+						fmt.Sprintf("item at index #%d of slice", i),
+					)
+				}
+
+				items = loadEventsForAggregate(
+					tc.Context,
+					repository,
+					"<aggregate>",
+					"<instance-b>",
+					item3.Envelope.MetaData.MessageId,
 				)
 
 				for i, item := range items {

--- a/persistence/internal/providertest/eventstore/repository.go
+++ b/persistence/internal/providertest/eventstore/repository.go
@@ -321,6 +321,13 @@ func DeclareRepositoryTests(tc *common.TestContext) {
 					item2.Envelope.MetaData.MessageId,
 				)
 				gomega.Expect(err).Should(gomega.HaveOccurred())
+				gomega.Expect(err).To(
+					gomega.MatchError(
+						"message with ID '" +
+							item2.Envelope.MetaData.MessageId +
+							"' cannot be found",
+					),
+				)
 			})
 
 			ginkgo.It("does not return an error if events exist beyond the end offset", func() {

--- a/persistence/internal/providertest/eventstore/repository.go
+++ b/persistence/internal/providertest/eventstore/repository.go
@@ -258,7 +258,7 @@ func DeclareRepositoryTests(tc *common.TestContext) {
 				}
 			})
 
-			ginkgo.It("matches the events from the source only after the given message id", func() {
+			ginkgo.It("only matches the events after the barrier message", func() {
 				expectedA := []*eventstore.Item{item2}
 				expectedB := []*eventstore.Item{item3}
 
@@ -306,7 +306,7 @@ func DeclareRepositoryTests(tc *common.TestContext) {
 				}
 			})
 
-			ginkgo.It("returns an error if the message with the given id is not found", func() {
+			ginkgo.It("returns an error if the barrier message is not found", func() {
 				saveEvents(
 					tc.Context,
 					dataStore,

--- a/persistence/internal/providertest/eventstore/repository.go
+++ b/persistence/internal/providertest/eventstore/repository.go
@@ -210,7 +210,7 @@ func DeclareRepositoryTests(tc *common.TestContext) {
 				gomega.Expect(items).To(gomega.BeEmpty())
 			})
 
-			ginkgo.It("returns a result containing the events that match the aggregate instance", func() {
+			ginkgo.It("returns a result containing the events that match the source instance", func() {
 				expectedA := []*eventstore.Item{item0, item2}
 				expectedB := []*eventstore.Item{item1, item3}
 
@@ -258,7 +258,7 @@ func DeclareRepositoryTests(tc *common.TestContext) {
 				}
 			})
 
-			ginkgo.It("matches the events for the aggregate only from the given message id, if specified ", func() {
+			ginkgo.It("matches the events from the source only after the given message id", func() {
 				expectedA := []*eventstore.Item{item2}
 				expectedB := []*eventstore.Item{item3}
 
@@ -278,7 +278,7 @@ func DeclareRepositoryTests(tc *common.TestContext) {
 					repository,
 					"<aggregate>",
 					"<instance-a>",
-					item2.Envelope.MetaData.MessageId,
+					item0.Envelope.MetaData.MessageId,
 				)
 
 				for i, item := range items {
@@ -294,7 +294,7 @@ func DeclareRepositoryTests(tc *common.TestContext) {
 					repository,
 					"<aggregate>",
 					"<instance-b>",
-					item3.Envelope.MetaData.MessageId,
+					item1.Envelope.MetaData.MessageId,
 				)
 
 				for i, item := range items {
@@ -362,7 +362,7 @@ func DeclareRepositoryTests(tc *common.TestContext) {
 						repository,
 						"<aggregate>",
 						"<instance-a>",
-						item0.Envelope.MetaData.MessageId,
+						"",
 					)
 					gomega.Expect(items).To(gomega.HaveLen(2))
 				}

--- a/persistence/internal/providertest/eventstore/repository.go
+++ b/persistence/internal/providertest/eventstore/repository.go
@@ -318,15 +318,11 @@ func DeclareRepositoryTests(tc *common.TestContext) {
 					tc.Context,
 					"<aggregate>",
 					"<instance-a>",
-					item2.ID(),
+					"<unknown>",
 				)
 				gomega.Expect(err).Should(gomega.HaveOccurred())
 				gomega.Expect(err).To(
-					gomega.MatchError(
-						"message with ID '" +
-							item2.ID() +
-							"' cannot be found",
-					),
+					gomega.MatchError("message with ID '<unknown>' cannot be found"),
 				)
 			})
 

--- a/persistence/internal/providertest/eventstore/repository.go
+++ b/persistence/internal/providertest/eventstore/repository.go
@@ -306,6 +306,23 @@ func DeclareRepositoryTests(tc *common.TestContext) {
 				}
 			})
 
+			ginkgo.It("returns an error if the message with the given id is not found", func() {
+				saveEvents(
+					tc.Context,
+					dataStore,
+					item0.Envelope,
+					item1.Envelope,
+				)
+
+				_, err := repository.LoadEventsBySource(
+					tc.Context,
+					"<aggregate>",
+					"<instance-a>",
+					item2.Envelope.MetaData.MessageId,
+				)
+				gomega.Expect(err).Should(gomega.HaveOccurred())
+			})
+
 			ginkgo.It("does not return an error if events exist beyond the end offset", func() {
 				res, err := repository.LoadEventsBySource(tc.Context, "<aggregate>", "<instance-a>", "")
 				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
@@ -376,7 +393,6 @@ func DeclareRepositoryTests(tc *common.TestContext) {
 				go fn2()
 				g.Wait()
 			})
-
 		})
 
 		ginkgo.Describe("type eventstore.Result", func() {

--- a/persistence/internal/providertest/eventstore/repository.go
+++ b/persistence/internal/providertest/eventstore/repository.go
@@ -278,7 +278,7 @@ func DeclareRepositoryTests(tc *common.TestContext) {
 					repository,
 					"<aggregate>",
 					"<instance-a>",
-					item0.Envelope.MetaData.MessageId,
+					item0.ID(),
 				)
 
 				for i, item := range items {
@@ -294,7 +294,7 @@ func DeclareRepositoryTests(tc *common.TestContext) {
 					repository,
 					"<aggregate>",
 					"<instance-b>",
-					item1.Envelope.MetaData.MessageId,
+					item1.ID(),
 				)
 
 				for i, item := range items {
@@ -318,13 +318,13 @@ func DeclareRepositoryTests(tc *common.TestContext) {
 					tc.Context,
 					"<aggregate>",
 					"<instance-a>",
-					item2.Envelope.MetaData.MessageId,
+					item2.ID(),
 				)
 				gomega.Expect(err).Should(gomega.HaveOccurred())
 				gomega.Expect(err).To(
 					gomega.MatchError(
 						"message with ID '" +
-							item2.Envelope.MetaData.MessageId +
+							item2.ID() +
 							"' cannot be found",
 					),
 				)

--- a/persistence/internal/providertest/eventstore/repository.go
+++ b/persistence/internal/providertest/eventstore/repository.go
@@ -184,7 +184,102 @@ func DeclareRepositoryTests(tc *common.TestContext) {
 				),
 			)
 
-			ginkgo.It("allows concurrent filtered consumers for the same application", func() {
+			ginkgo.It("does not return an error if events exist beyond the end offset", func() {
+				res, err := repository.QueryEvents(tc.Context, eventstore.Query{})
+				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+				defer res.Close()
+
+				saveEvents(
+					tc.Context,
+					dataStore,
+					item0.Envelope,
+					item1.Envelope,
+				)
+
+				// The implementation may or may not expose these newly
+				// appended events to the caller. We simply want to ensure
+				// that no error occurs.
+				_, _, err = res.Next(tc.Context)
+				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+			})
+		})
+
+		ginkgo.Describe("func LoadEventsForAggregate()", func() {
+			ginkgo.It("returns an empty result if the store is empty", func() {
+				items := loadEventsForAggregate(tc.Context, repository, "<aggregate>", "<instance-a>", "")
+				gomega.Expect(items).To(gomega.BeEmpty())
+			})
+
+			ginkgo.It("it returns a result containing the events that match the aggregate instance", func() {
+				expectedA := []*eventstore.Item{item0, item2}
+				expectedB := []*eventstore.Item{item1, item3}
+
+				saveEvents(
+					tc.Context,
+					dataStore,
+					item0.Envelope,
+					item1.Envelope,
+					item2.Envelope,
+					item3.Envelope,
+					item4.Envelope,
+					item5.Envelope,
+				)
+
+				items := loadEventsForAggregate(
+					tc.Context,
+					repository,
+					"<aggregate>",
+					"<instance-a>",
+					item0.Envelope.MetaData.MessageId,
+				)
+
+				for i, item := range items {
+					expectItemToEqual(
+						item,
+						expectedA[i],
+						fmt.Sprintf("item at index #%d of slice", i),
+					)
+				}
+
+				items = loadEventsForAggregate(
+					tc.Context,
+					repository,
+					"<aggregate>",
+					"<instance-b>",
+					item1.Envelope.MetaData.MessageId,
+				)
+
+				for i, item := range items {
+					expectItemToEqual(
+						item,
+						expectedB[i],
+						fmt.Sprintf("item at index #%d of slice", i),
+					)
+				}
+			})
+
+			ginkgo.It("does not return an error if events exist beyond the end offset", func() {
+				res, err := repository.LoadEventsForAggregate(tc.Context, "<aggregate>", "<instance-a>", "")
+				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+				defer res.Close()
+
+				saveEvents(
+					tc.Context,
+					dataStore,
+					item0.Envelope,
+					item1.Envelope,
+				)
+
+				// The implementation may or may not expose these newly
+				// appended events to the caller. We simply want to ensure
+				// that no error occurs.
+				_, _, err = res.Next(tc.Context)
+				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+			})
+		})
+
+		ginkgo.Describe("func QueryEvents() and LoadEventsForAggregate()", func() {
+			ginkgo.It("allows concurrent consumers for the same application", func() {
 				saveEvents(
 					tc.Context,
 					dataStore,
@@ -204,38 +299,36 @@ func DeclareRepositoryTests(tc *common.TestContext) {
 
 				var g sync.WaitGroup
 
-				fn := func() {
+				fn1 := func() {
 					defer g.Done()
 					defer ginkgo.GinkgoRecover()
 					items := queryEvents(tc.Context, repository, q)
 					gomega.Expect(items).To(gomega.HaveLen(2))
 				}
 
-				g.Add(3)
-				go fn()
-				go fn()
-				go fn()
+				fn2 := func() {
+					defer g.Done()
+					defer ginkgo.GinkgoRecover()
+					items := loadEventsForAggregate(
+						tc.Context,
+						repository,
+						"<aggregate>",
+						"<instance-a>",
+						item0.Envelope.MetaData.MessageId,
+					)
+					gomega.Expect(items).To(gomega.HaveLen(2))
+				}
+
+				g.Add(6)
+				go fn1()
+				go fn2()
+				go fn1()
+				go fn2()
+				go fn1()
+				go fn2()
 				g.Wait()
 			})
 
-			ginkgo.It("does not return an error if events exist beyond the end offset", func() {
-				res, err := repository.QueryEvents(tc.Context, eventstore.Query{})
-				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
-				defer res.Close()
-
-				saveEvents(
-					tc.Context,
-					dataStore,
-					item0.Envelope,
-					item1.Envelope,
-				)
-
-				// The implementation may or may not expose these newly
-				// appended events to the caller. We simply want to ensure
-				// that no error occurs.
-				_, _, err = res.Next(tc.Context)
-				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
-			})
 		})
 
 		ginkgo.Describe("type eventstore.Result", func() {

--- a/persistence/internal/providertest/eventstore/repository.go
+++ b/persistence/internal/providertest/eventstore/repository.go
@@ -326,7 +326,7 @@ func DeclareRepositoryTests(tc *common.TestContext) {
 			})
 		})
 
-		ginkgo.Describe("func QueryEvents() and loadEventsBySource()", func() {
+		ginkgo.Describe("func QueryEvents() and LoadEventsBySource()", func() {
 			ginkgo.It("allows concurrent consumers for the same application", func() {
 				saveEvents(
 					tc.Context,

--- a/persistence/internal/providertest/eventstore/util.go
+++ b/persistence/internal/providertest/eventstore/util.go
@@ -78,18 +78,18 @@ func queryEvents(
 	}
 }
 
-// loadEventsForAggregate loads the event items for the aggregate with the given
-// key, and instance id.
+// loadEventsBySource loads the events produced by the specified source with
+// the given handler key and id.
 //
 // d is the optional parameter, it represents ID of the message that was
 // recorded when the instance was last destroyed.
-func loadEventsForAggregate(
+func loadEventsBySource(
 	ctx context.Context,
 	r eventstore.Repository,
 	hk, id string,
 	d string,
 ) []*eventstore.Item {
-	res, err := r.LoadEventsForAggregate(ctx, hk, id, d)
+	res, err := r.LoadEventsBySource(ctx, hk, id, d)
 	gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 	defer res.Close()
 

--- a/persistence/internal/providertest/eventstore/util.go
+++ b/persistence/internal/providertest/eventstore/util.go
@@ -93,7 +93,7 @@ func loadEventsBySource(
 	hk, id string,
 	m string,
 ) []*eventstore.Item {
-	res, err := r.LoadEventsBySource(ctx, hk, id, d)
+	res, err := r.LoadEventsBySource(ctx, hk, id, m)
 	gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 	defer res.Close()
 

--- a/persistence/internal/providertest/eventstore/util.go
+++ b/persistence/internal/providertest/eventstore/util.go
@@ -78,11 +78,15 @@ func queryEvents(
 	}
 }
 
-// loadEventsBySource loads the events produced by the specified source with
-// the given handler key and id.
+// loadEventsBySource loads the events produced by a specific handler.
 //
-// d is the optional parameter, it represents ID of the message that was
-// recorded when the instance was last destroyed.
+// hk is the handler's identity key.
+//
+// id is the instance ID, which must be empty if the handler type does not
+// use instances.
+//
+// m is ID of a "barrier" message. If supplied, the results are limited to
+// events with higher offsets than the barrier message.
 func loadEventsBySource(
 	ctx context.Context,
 	r eventstore.Repository,

--- a/persistence/internal/providertest/eventstore/util.go
+++ b/persistence/internal/providertest/eventstore/util.go
@@ -91,7 +91,7 @@ func loadEventsBySource(
 	ctx context.Context,
 	r eventstore.Repository,
 	hk, id string,
-	d string,
+	m string,
 ) []*eventstore.Item {
 	res, err := r.LoadEventsBySource(ctx, hk, id, d)
 	gomega.Expect(err).ShouldNot(gomega.HaveOccurred())

--- a/persistence/internal/providertest/eventstore/util.go
+++ b/persistence/internal/providertest/eventstore/util.go
@@ -77,3 +77,32 @@ func queryEvents(
 		items = append(items, i)
 	}
 }
+
+// loadEventsForAggregate loads the event items for the aggregate with the given
+// key, and instance id.
+//
+// d is the optional parameter, it represents ID of the message that was
+// recorded when the instance was last destroyed, if any.
+func loadEventsForAggregate(
+	ctx context.Context,
+	r eventstore.Repository,
+	hk, id string,
+	d string,
+) []*eventstore.Item {
+	res, err := r.LoadEventsForAggregate(ctx, hk, id, d)
+	gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+	defer res.Close()
+
+	var items []*eventstore.Item
+
+	for {
+		i, ok, err := res.Next(ctx)
+		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+
+		if !ok {
+			return items
+		}
+
+		items = append(items, i)
+	}
+}

--- a/persistence/internal/providertest/eventstore/util.go
+++ b/persistence/internal/providertest/eventstore/util.go
@@ -82,7 +82,7 @@ func queryEvents(
 // key, and instance id.
 //
 // d is the optional parameter, it represents ID of the message that was
-// recorded when the instance was last destroyed, if any.
+// recorded when the instance was last destroyed.
 func loadEventsForAggregate(
 	ctx context.Context,
 	r eventstore.Repository,

--- a/persistence/provider/boltdb/eventstore.go
+++ b/persistence/provider/boltdb/eventstore.go
@@ -2,7 +2,6 @@ package boltdb
 
 import (
 	"context"
-	"fmt"
 	"math"
 
 	"github.com/dogmatiq/infix/draftspecs/envelopespec"
@@ -155,10 +154,9 @@ func (r *eventStoreRepository) LoadEventsBySource(
 				); exists {
 					v := messageIDs.Get([]byte(d))
 					if v == nil {
-						err = fmt.Errorf(
-							"message with id %s is not found",
-							d,
-						)
+						err = &eventstore.UnknownMessageError{
+							MessageID: d,
+						}
 
 						return
 					}

--- a/persistence/provider/boltdb/eventstore.go
+++ b/persistence/provider/boltdb/eventstore.go
@@ -160,9 +160,14 @@ func (r *eventStoreRepository) LoadEventsBySource(
 		db:     r.db,
 		appKey: r.appKey,
 		pred: func(i *eventstore.Item) bool {
-			return hk == i.Envelope.MetaData.Source.Handler.Key &&
-				id == i.Envelope.MetaData.Source.InstanceId &&
-				i.Offset >= o
+			ok := hk == i.Envelope.MetaData.Source.Handler.Key &&
+				id == i.Envelope.MetaData.Source.InstanceId
+
+			if d != "" {
+				return ok && i.Offset > o
+			}
+
+			return ok
 		},
 		offset: o,
 	}, nil

--- a/persistence/provider/boltdb/eventstore.go
+++ b/persistence/provider/boltdb/eventstore.go
@@ -70,7 +70,7 @@ func (t *transaction) SaveEvent(
 
 	messageIDs := bboltx.CreateBucketIfNotExists(
 		store,
-		eventStoreMesssageIDsBucketKey,
+		eventStoreMessageIDsBucketKey,
 	)
 
 	bboltx.Put(
@@ -151,7 +151,7 @@ func (r *eventStoreRepository) LoadEventsBySource(
 					tx,
 					r.appKey,
 					eventStoreBucketKey,
-					eventStoreMesssageIDsBucketKey,
+					eventStoreMessageIDsBucketKey,
 				); exists {
 					v := messageIDs.Get([]byte(d))
 					if v == nil {

--- a/persistence/provider/boltdb/eventstore.go
+++ b/persistence/provider/boltdb/eventstore.go
@@ -128,11 +128,16 @@ func (r *eventStoreRepository) NextEventOffset(
 	return next, err
 }
 
-// LoadEventsBySource loads the events produced by the specified source with
-// the given handler key and id.
+// LoadEventsBySource loads the events produced by a specific handler.
 //
-// d is the optional parameter, it represents ID of the message that was
-// recorded when the instance was last destroyed.
+// hk is the handler's identity key.
+//
+// id is the instance ID, which must be empty if the handler type does not
+// use instances.
+//
+// m is ID of a "barrier" message. If supplied, the results are limited to
+// events with higher offsets than the barrier message. If the message
+// cannot be found, UnknownMessageError is returned.
 func (r *eventStoreRepository) LoadEventsBySource(
 	ctx context.Context,
 	hk, id, d string,

--- a/persistence/provider/boltdb/eventstore.go
+++ b/persistence/provider/boltdb/eventstore.go
@@ -2,7 +2,6 @@ package boltdb
 
 import (
 	"context"
-	"math"
 
 	"github.com/dogmatiq/infix/draftspecs/envelopespec"
 	"github.com/dogmatiq/infix/internal/x/bboltx"
@@ -241,7 +240,6 @@ func (r *eventStoreResult) Next(
 
 // Close closes the cursor.
 func (r *eventStoreResult) Close() error {
-	r.offset = math.MaxUint64
 	return nil
 }
 

--- a/persistence/provider/boltdb/eventstore.go
+++ b/persistence/provider/boltdb/eventstore.go
@@ -128,12 +128,12 @@ func (r *eventStoreRepository) NextEventOffset(
 	return next, err
 }
 
-// LoadEventsForAggregate loads the events for the aggregate with the given
-// key and id.
+// LoadEventsBySource loads the events produced by the specified source with
+// the given handler key and id.
 //
 // d is the optional parameter, it represents ID of the message that was
 // recorded when the instance was last destroyed.
-func (r *eventStoreRepository) LoadEventsForAggregate(
+func (r *eventStoreRepository) LoadEventsBySource(
 	ctx context.Context,
 	hk, id, d string,
 ) (eventstore.Result, error) {

--- a/persistence/provider/boltdb/eventstore.go
+++ b/persistence/provider/boltdb/eventstore.go
@@ -161,8 +161,8 @@ func (r *eventStoreRepository) LoadEventsForAggregate(
 		appKey: r.appKey,
 		pred: func(i *eventstore.Item) bool {
 			return hk == i.Envelope.MetaData.Source.Handler.Key &&
-				id != i.Envelope.MetaData.Source.InstanceId &&
-				i.Offset > o
+				id == i.Envelope.MetaData.Source.InstanceId &&
+				i.Offset >= o
 		},
 		offset: o,
 	}, nil

--- a/persistence/provider/boltdb/eventstore.go
+++ b/persistence/provider/boltdb/eventstore.go
@@ -23,7 +23,7 @@ var (
 	// buffers.
 	eventStoreItemsBucketKey = []byte("items")
 
-	// eventStoreMessageIDsBucketKey is the key for a child bucket that indexes
+	// eventStoreOffsetsBucketKey is the key for a child bucket that indexes
 	// event message id against the event offsets.
 	//
 	// The keys are the string message IDs converted to bytes. The
@@ -68,7 +68,7 @@ func (t *transaction) SaveEvent(
 
 	messageIDs := bboltx.CreateBucketIfNotExists(
 		store,
-		eventStoreMessageIDsBucketKey,
+		eventStoreOffsetsBucketKey,
 	)
 
 	bboltx.Put(
@@ -146,7 +146,7 @@ func (r *eventStoreRepository) LoadEventsBySource(
 		err error
 	)
 
-	if d != "" {
+	if m != "" {
 		r.db.View(
 			ctx,
 			func(tx *bbolt.Tx) {
@@ -154,12 +154,12 @@ func (r *eventStoreRepository) LoadEventsBySource(
 					tx,
 					r.appKey,
 					eventStoreBucketKey,
-					eventStoreMessageIDsBucketKey,
+					eventStoreOffsetsBucketKey,
 				); exists {
-					v := messageIDs.Get([]byte(d))
+					v := messageIDs.Get([]byte(m))
 					if v == nil {
 						err = &eventstore.UnknownMessageError{
-							MessageID: d,
+							MessageID: m,
 						}
 
 						return

--- a/persistence/provider/boltdb/eventstore.go
+++ b/persistence/provider/boltdb/eventstore.go
@@ -178,12 +178,6 @@ func (r *eventStoreRepository) LoadEventsBySource(
 		pred: func(i *eventstore.Item) bool {
 			return hk == i.Envelope.MetaData.Source.Handler.Key &&
 				id == i.Envelope.MetaData.Source.InstanceId
-
-			if d != "" {
-				return ok && i.Offset > o
-			}
-
-			return ok
 		},
 		offset: o,
 	}, nil

--- a/persistence/provider/boltdb/eventstore.go
+++ b/persistence/provider/boltdb/eventstore.go
@@ -66,13 +66,13 @@ func (t *transaction) SaveEvent(
 
 	saveEventStoreItem(items, o, env)
 
-	messageIDs := bboltx.CreateBucketIfNotExists(
+	offsets := bboltx.CreateBucketIfNotExists(
 		store,
 		eventStoreOffsetsBucketKey,
 	)
 
 	bboltx.Put(
-		messageIDs,
+		offsets,
 		[]byte(env.MetaData.MessageId),
 		marshalUint64(o),
 	)
@@ -150,13 +150,13 @@ func (r *eventStoreRepository) LoadEventsBySource(
 		r.db.View(
 			ctx,
 			func(tx *bbolt.Tx) {
-				if messageIDs, exists := bboltx.TryBucket(
+				if offsets, exists := bboltx.TryBucket(
 					tx,
 					r.appKey,
 					eventStoreBucketKey,
 					eventStoreOffsetsBucketKey,
 				); exists {
-					v := messageIDs.Get([]byte(m))
+					v := offsets.Get([]byte(m))
 					if v == nil {
 						err = &eventstore.UnknownMessageError{
 							MessageID: m,

--- a/persistence/provider/boltdb/eventstore.go
+++ b/persistence/provider/boltdb/eventstore.go
@@ -28,7 +28,7 @@ var (
 	//
 	// The keys are the string message IDs converted to bytes. The
 	// values are the event offsets encoded as 8-byte big-endian packets.
-	eventStoreMessageIDsBucketKey = []byte("message_ids")
+	eventStoreOffsetsBucketKey = []byte("offsets")
 
 	// eventStoreNextOffsetKey is the key of a value within the root bucket that
 	// contains the next unused offset, again encoded as 8-byte big-endian
@@ -139,7 +139,7 @@ func (r *eventStoreRepository) NextEventOffset(
 // cannot be found, UnknownMessageError is returned.
 func (r *eventStoreRepository) LoadEventsBySource(
 	ctx context.Context,
-	hk, id, d string,
+	hk, id, m string,
 ) (eventstore.Result, error) {
 	var (
 		o   uint64
@@ -165,6 +165,8 @@ func (r *eventStoreRepository) LoadEventsBySource(
 						return
 					}
 
+					// Increment the offset to match all messages
+					// after the barrier message exclusively.
 					o = unmarshalUint64(v) + 1
 				}
 			})

--- a/persistence/provider/boltdb/eventstore.go
+++ b/persistence/provider/boltdb/eventstore.go
@@ -132,7 +132,7 @@ func (r *eventStoreRepository) NextEventOffset(
 // key and id.
 //
 // d is the optional parameter, it represents ID of the message that was
-// recorded when the instance was last destroyed, if any.
+// recorded when the instance was last destroyed.
 func (r *eventStoreRepository) LoadEventsForAggregate(
 	ctx context.Context,
 	hk, id, d string,

--- a/persistence/provider/boltdb/eventstore.go
+++ b/persistence/provider/boltdb/eventstore.go
@@ -25,12 +25,12 @@ var (
 	// buffers.
 	eventStoreItemsBucketKey = []byte("items")
 
-	// eventStoreMesssageIDsBucketKey is the key for a child bucket that indexes
+	// eventStoreMessageIDsBucketKey is the key for a child bucket that indexes
 	// event message id against the event offsets.
 	//
 	// The keys are the string message IDs converted to bytes. The
 	// values are the event offsets encoded as 8-byte big-endian packets.
-	eventStoreMesssageIDsBucketKey = []byte("message_ids")
+	eventStoreMessageIDsBucketKey = []byte("message_ids")
 
 	// eventStoreNextOffsetKey is the key of a value within the root bucket that
 	// contains the next unused offset, again encoded as 8-byte big-endian
@@ -163,7 +163,7 @@ func (r *eventStoreRepository) LoadEventsBySource(
 						return
 					}
 
-					o = unmarshalUint64(v)
+					o = unmarshalUint64(v) + 1
 				}
 			})
 	}
@@ -176,7 +176,7 @@ func (r *eventStoreRepository) LoadEventsBySource(
 		db:     r.db,
 		appKey: r.appKey,
 		pred: func(i *eventstore.Item) bool {
-			ok := hk == i.Envelope.MetaData.Source.Handler.Key &&
+			return hk == i.Envelope.MetaData.Source.Handler.Key &&
 				id == i.Envelope.MetaData.Source.InstanceId
 
 			if d != "" {

--- a/persistence/provider/memory/eventstore.go
+++ b/persistence/provider/memory/eventstore.go
@@ -2,6 +2,7 @@ package memory
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/dogmatiq/infix/draftspecs/envelopespec"
 	"github.com/dogmatiq/infix/persistence/subsystem/eventstore"
@@ -53,9 +54,15 @@ func (r *eventStoreRepository) LoadEventsBySource(
 	var o uint64
 
 	if d != "" {
-		if o1, ok := r.db.event.messageIDs[d]; ok {
-			o = o1
+		o1, ok := r.db.event.messageIDs[d]
+		if !ok {
+			return nil, fmt.Errorf(
+				"message with id %s is not found",
+				d,
+			)
 		}
+
+		o = o1
 	}
 
 	return &eventStoreResult{

--- a/persistence/provider/memory/eventstore.go
+++ b/persistence/provider/memory/eventstore.go
@@ -41,11 +41,16 @@ func (r *eventStoreRepository) NextEventOffset(
 	return uint64(next), nil
 }
 
-// LoadEventsBySource loads the events produced by the specified source with
-// the given handler key and id.
+// LoadEventsBySource loads the events produced by a specific handler.
 //
-// d is the optional parameter, it represents ID of the message that was
-// recorded when the instance was last destroyed.
+// hk is the handler's identity key.
+//
+// id is the instance ID, which must be empty if the handler type does not
+// use instances.
+//
+// m is ID of a "barrier" message. If supplied, the results are limited to
+// events with higher offsets than the barrier message. If the message
+// cannot be found, UnknownMessageError is returned.
 func (r *eventStoreRepository) LoadEventsBySource(
 	ctx context.Context,
 	hk, id, d string,

--- a/persistence/provider/memory/eventstore.go
+++ b/persistence/provider/memory/eventstore.go
@@ -41,12 +41,12 @@ func (r *eventStoreRepository) NextEventOffset(
 	return uint64(next), nil
 }
 
-// LoadEventsForAggregate loads the events for the aggregate with the given
-// key and id.
+// LoadEventsBySource loads the events produced by the specified source with
+// the given handler key and id.
 //
 // d is the optional parameter, it represents ID of the message that was
 // recorded when the instance was last destroyed.
-func (r *eventStoreRepository) LoadEventsForAggregate(
+func (r *eventStoreRepository) LoadEventsBySource(
 	ctx context.Context,
 	hk, id, d string,
 ) (eventstore.Result, error) {

--- a/persistence/provider/memory/eventstore.go
+++ b/persistence/provider/memory/eventstore.go
@@ -54,7 +54,8 @@ func (r *eventStoreRepository) LoadEventsBySource(
 	var o uint64
 
 	if d != "" {
-		o1, ok := r.db.event.messageIDs[d]
+		var bool ok
+		o, ok = r.db.event.messageIDs[d]
 		if !ok {
 			return nil, fmt.Errorf(
 				"message with id %s is not found",
@@ -68,7 +69,7 @@ func (r *eventStoreRepository) LoadEventsBySource(
 	return &eventStoreResult{
 		db: r.db,
 		pred: func(i *eventstore.Item) bool {
-			ok := hk == i.Envelope.MetaData.Source.Handler.Key &&
+			return hk == i.Envelope.MetaData.Source.Handler.Key &&
 				id == i.Envelope.MetaData.Source.InstanceId
 
 			if d != "" {

--- a/persistence/provider/memory/eventstore.go
+++ b/persistence/provider/memory/eventstore.go
@@ -2,7 +2,6 @@ package memory
 
 import (
 	"context"
-	"math"
 
 	"github.com/dogmatiq/infix/draftspecs/envelopespec"
 	"github.com/dogmatiq/infix/persistence/subsystem/eventstore"
@@ -136,7 +135,6 @@ func (r *eventStoreResult) Next(
 
 // Close closes the cursor.
 func (r *eventStoreResult) Close() error {
-	r.index = math.MaxInt64
 	return nil
 }
 

--- a/persistence/provider/memory/eventstore.go
+++ b/persistence/provider/memory/eventstore.go
@@ -2,6 +2,7 @@ package memory
 
 import (
 	"context"
+	"math"
 
 	"github.com/dogmatiq/infix/draftspecs/envelopespec"
 	"github.com/dogmatiq/infix/persistence/subsystem/eventstore"
@@ -135,6 +136,7 @@ func (r *eventStoreResult) Next(
 
 // Close closes the cursor.
 func (r *eventStoreResult) Close() error {
+	r.index = math.MaxInt64
 	return nil
 }
 

--- a/persistence/provider/memory/eventstore.go
+++ b/persistence/provider/memory/eventstore.go
@@ -42,6 +42,18 @@ func (r *eventStoreRepository) NextEventOffset(
 	return uint64(next), nil
 }
 
+// LoadEventsForAggregate loads the events for the aggregate with the given
+// key and id.
+//
+// d is the optional parameter, it represents ID of the message that was
+// recorded when the instance was last destroyed.
+func (r *eventStoreRepository) LoadEventsForAggregate(
+	ctx context.Context,
+	hk, id, d string,
+) (eventstore.Result, error) {
+	panic("not implemented")
+}
+
 // QueryEvents queries events in the repository.
 func (r *eventStoreRepository) QueryEvents(
 	ctx context.Context,

--- a/persistence/provider/memory/eventstore.go
+++ b/persistence/provider/memory/eventstore.go
@@ -54,7 +54,7 @@ func (r *eventStoreRepository) LoadEventsBySource(
 	var o uint64
 
 	if d != "" {
-		var bool ok
+		var ok bool
 		o, ok = r.db.event.messageIDs[d]
 		if !ok {
 			return nil, fmt.Errorf(
@@ -63,7 +63,7 @@ func (r *eventStoreRepository) LoadEventsBySource(
 			)
 		}
 
-		o = o1
+		o = o + 1
 	}
 
 	return &eventStoreResult{
@@ -71,12 +71,6 @@ func (r *eventStoreRepository) LoadEventsBySource(
 		pred: func(i *eventstore.Item) bool {
 			return hk == i.Envelope.MetaData.Source.Handler.Key &&
 				id == i.Envelope.MetaData.Source.InstanceId
-
-			if d != "" {
-				return ok && i.Offset > o
-			}
-
-			return ok
 		},
 		index: int(o),
 	}, nil

--- a/persistence/provider/memory/eventstore.go
+++ b/persistence/provider/memory/eventstore.go
@@ -57,12 +57,12 @@ func (r *eventStoreRepository) LoadEventsBySource(
 ) (eventstore.Result, error) {
 	var o uint64
 
-	if d != "" {
+	if m != "" {
 		var ok bool
-		o, ok = r.db.event.messageIDs[d]
+		o, ok = r.db.event.offsets[m]
 		if !ok {
 			return nil, eventstore.UnknownMessageError{
-				MessageID: d,
+				MessageID: m,
 			}
 		}
 
@@ -168,7 +168,7 @@ func (cs *eventStoreChangeSet) stageSave(
 
 // eventStoreDatabase contains data that is committed to the event store.
 type eventStoreDatabase struct {
-	items      []*eventstore.Item
+	items   []*eventstore.Item
 	offsets map[string]uint64
 }
 
@@ -176,12 +176,12 @@ type eventStoreDatabase struct {
 func (db *eventStoreDatabase) apply(cs *eventStoreChangeSet) {
 	db.items = append(db.items, cs.items...)
 
-	if db.messageIDs == nil {
-		db.messageIDs = make(map[string]uint64)
+	if db.offsets == nil {
+		db.offsets = make(map[string]uint64)
 	}
 
 	for _, item := range cs.items {
-		db.messageIDs[item.Envelope.MetaData.MessageId] = item.Offset
+		db.offsets[item.Envelope.MetaData.MessageId] = item.Offset
 	}
 }
 

--- a/persistence/provider/memory/eventstore.go
+++ b/persistence/provider/memory/eventstore.go
@@ -181,7 +181,7 @@ func (db *eventStoreDatabase) apply(cs *eventStoreChangeSet) {
 	}
 
 	for _, item := range cs.items {
-		db.offsets[item.Envelope.MetaData.MessageId] = item.Offset
+		db.offsets[item.ID()] = item.Offset
 	}
 }
 

--- a/persistence/provider/memory/eventstore.go
+++ b/persistence/provider/memory/eventstore.go
@@ -61,9 +61,14 @@ func (r *eventStoreRepository) LoadEventsBySource(
 	return &eventStoreResult{
 		db: r.db,
 		pred: func(i *eventstore.Item) bool {
-			return hk == i.Envelope.MetaData.Source.Handler.Key &&
-				id == i.Envelope.MetaData.Source.InstanceId &&
-				i.Offset >= o
+			ok := hk == i.Envelope.MetaData.Source.Handler.Key &&
+				id == i.Envelope.MetaData.Source.InstanceId
+
+			if d != "" {
+				return ok && i.Offset > o
+			}
+
+			return ok
 		},
 		index: int(o),
 	}, nil

--- a/persistence/provider/memory/eventstore.go
+++ b/persistence/provider/memory/eventstore.go
@@ -2,7 +2,6 @@ package memory
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/dogmatiq/infix/draftspecs/envelopespec"
 	"github.com/dogmatiq/infix/persistence/subsystem/eventstore"
@@ -57,10 +56,9 @@ func (r *eventStoreRepository) LoadEventsBySource(
 		var ok bool
 		o, ok = r.db.event.messageIDs[d]
 		if !ok {
-			return nil, fmt.Errorf(
-				"message with id %s is not found",
-				d,
-			)
+			return nil, eventstore.UnknownMessageError{
+				MessageID: d,
+			}
 		}
 
 		o = o + 1

--- a/persistence/provider/memory/eventstore.go
+++ b/persistence/provider/memory/eventstore.go
@@ -53,7 +53,7 @@ func (r *eventStoreRepository) NextEventOffset(
 // cannot be found, UnknownMessageError is returned.
 func (r *eventStoreRepository) LoadEventsBySource(
 	ctx context.Context,
-	hk, id, d string,
+	hk, id, m string,
 ) (eventstore.Result, error) {
 	var o uint64
 
@@ -66,7 +66,9 @@ func (r *eventStoreRepository) LoadEventsBySource(
 			}
 		}
 
-		o = o + 1
+		// Increment the offset to select all messages after the barrier
+		// message exclusively.
+		o++
 	}
 
 	return &eventStoreResult{
@@ -167,7 +169,7 @@ func (cs *eventStoreChangeSet) stageSave(
 // eventStoreDatabase contains data that is committed to the event store.
 type eventStoreDatabase struct {
 	items      []*eventstore.Item
-	messageIDs map[string]uint64
+	offsets map[string]uint64
 }
 
 // apply updates the database to include the changes in cs.

--- a/persistence/provider/sql/eventstore.go
+++ b/persistence/provider/sql/eventstore.go
@@ -87,7 +87,7 @@ type eventStoreDriver interface {
 	) (*sql.Rows, error)
 
 	// SelectOffsetByMessageID selects the offset of the message with the given
-	// ID.
+	// ID. It returns eventstore.UnknownMessageError if the message is not found.
 	SelectOffsetByMessageID(
 		ctx context.Context,
 		db *sql.DB,

--- a/persistence/provider/sql/eventstore.go
+++ b/persistence/provider/sql/eventstore.go
@@ -145,12 +145,12 @@ func (r *eventStoreRepository) NextEventOffset(
 	)
 }
 
-// LoadEventsForAggregate loads the events for the aggregate with the given
-// key and id.
+// LoadEventsBySource loads the events produced by the specified source with
+// the given handler key and id.
 //
 // d is the optional parameter, it represents ID of the message that was
 // recorded when the instance was last destroyed.
-func (r *eventStoreRepository) LoadEventsForAggregate(
+func (r *eventStoreRepository) LoadEventsBySource(
 	ctx context.Context,
 	hk, id, d string,
 ) (eventstore.Result, error) {

--- a/persistence/provider/sql/eventstore.go
+++ b/persistence/provider/sql/eventstore.go
@@ -145,6 +145,18 @@ func (r *eventStoreRepository) NextEventOffset(
 	)
 }
 
+// LoadEventsForAggregate loads the events for the aggregate with the given
+// key and id.
+//
+// d is the optional parameter, it represents ID of the message that was
+// recorded when the instance was last destroyed.
+func (r *eventStoreRepository) LoadEventsForAggregate(
+	ctx context.Context,
+	hk, id, d string,
+) (eventstore.Result, error) {
+	panic("not implemented")
+}
+
 // QueryEvents queries events in the repository.
 func (r *eventStoreRepository) QueryEvents(
 	ctx context.Context,

--- a/persistence/provider/sql/eventstore.go
+++ b/persistence/provider/sql/eventstore.go
@@ -175,7 +175,7 @@ func (r *eventStoreRepository) NextEventOffset(
 // cannot be found, UnknownMessageError is returned.
 func (r *eventStoreRepository) LoadEventsBySource(
 	ctx context.Context,
-	hk, id, d string,
+	hk, id, m string,
 ) (eventstore.Result, error) {
 	var o uint64
 
@@ -191,7 +191,7 @@ func (r *eventStoreRepository) LoadEventsBySource(
 			return nil, err
 		}
 
-		// increment the offset to select all messages after the barier 'd'
+		// Increment the offset to select all messages after the barrier
 		// message exclusively.
 		o++
 	}

--- a/persistence/provider/sql/eventstore.go
+++ b/persistence/provider/sql/eventstore.go
@@ -163,11 +163,16 @@ func (r *eventStoreRepository) NextEventOffset(
 	)
 }
 
-// LoadEventsBySource loads the events produced by the specified source with
-// the given handler key and id.
+// LoadEventsBySource loads the events produced by a specific handler.
 //
-// d is the optional parameter, it represents ID of the message that was
-// recorded when the instance was last destroyed.
+// hk is the handler's identity key.
+//
+// id is the instance ID, which must be empty if the handler type does not
+// use instances.
+//
+// m is ID of a "barrier" message. If supplied, the results are limited to
+// events with higher offsets than the barrier message. If the message
+// cannot be found, UnknownMessageError is returned.
 func (r *eventStoreRepository) LoadEventsBySource(
 	ctx context.Context,
 	hk, id, d string,

--- a/persistence/provider/sql/eventstore.go
+++ b/persistence/provider/sql/eventstore.go
@@ -179,13 +179,13 @@ func (r *eventStoreRepository) LoadEventsBySource(
 ) (eventstore.Result, error) {
 	var o uint64
 
-	if d != "" {
+	if m != "" {
 		var err error
 
 		o, err = r.driver.SelectOffsetByMessageID(
 			ctx,
 			r.db,
-			d,
+			m,
 		)
 		if err != nil {
 			return nil, err

--- a/persistence/provider/sql/eventstore.go
+++ b/persistence/provider/sql/eventstore.go
@@ -65,7 +65,7 @@ type eventStoreDriver interface {
 	) (uint64, error)
 
 	// SelectEventsByType selects events from the eventstore that match the
-	// given event types query.
+	// given query.
 	//
 	// f is a filter ID, as returned by InsertEventFilter(). If the query does
 	// not use a filter, f is zero.
@@ -77,9 +77,8 @@ type eventStoreDriver interface {
 		f int64,
 	) (*sql.Rows, error)
 
-	// SelectEventsBySource selects events from the eventstore that match the
-	// given source, namely the source's key and id. o is an optional offset
-	// parameter from which the messages should be loaded.
+	// SelectEventsBySource selects events from the eventstore that were
+	// produced by a specific handler.
 	SelectEventsBySource(
 		ctx context.Context,
 		db *sql.DB,
@@ -96,8 +95,7 @@ type eventStoreDriver interface {
 	) (uint64, error)
 
 	// ScanEvent scans the next event from a row-set returned by
-	// SelectEventsByType(), SelectEventsBySource(), and
-	// SelectEventsBySourceAfterMessage().
+	// SelectEventsByType() and SelectEventsBySource().
 	ScanEvent(
 		rows *sql.Rows,
 		i *eventstore.Item,

--- a/persistence/provider/sql/mysql/eventstore.go
+++ b/persistence/provider/sql/mysql/eventstore.go
@@ -301,7 +301,12 @@ func (driver) SelectOffsetByMessageID(
 		id,
 	)
 
-	err = row.Scan(&o)
+	if err = row.Scan(&o); err == sql.ErrNoRows {
+		err = eventstore.UnknownMessageError{
+			MessageID: id,
+		}
+	}
+
 	return
 }
 

--- a/persistence/provider/sql/mysql/schema.go
+++ b/persistence/provider/sql/mysql/schema.go
@@ -94,7 +94,7 @@ func createEventStoreSchema(ctx context.Context, db *sql.DB) {
 			INDEX repository_query (
 				source_app_key,
 				portable_name,
-				offset,
+				message_id,
 				source_handler_key,
 				source_instance_id
 			)

--- a/persistence/provider/sql/mysql/schema.go
+++ b/persistence/provider/sql/mysql/schema.go
@@ -76,7 +76,7 @@ func createEventStoreSchema(ctx context.Context, db *sql.DB) {
 		db,
 		`CREATE TABLE event (
 			offset              BIGINT UNSIGNED NOT NULL,
-			message_id          VARBINARY(255) NOT NULL,
+			message_id          VARBINARY(255) NOT NULL UNIQUE,
 			causation_id        VARBINARY(255) NOT NULL,
 			correlation_id      VARBINARY(255) NOT NULL,
 			source_app_name     VARBINARY(255) NOT NULL,
@@ -91,12 +91,16 @@ func createEventStoreSchema(ctx context.Context, db *sql.DB) {
 			data                LONGBLOB NOT NULL,
 
 			PRIMARY KEY (source_app_key, offset),
-			INDEX repository_query (
+			INDEX by_type (
 				source_app_key,
 				portable_name,
-				message_id,
+				offset
+			),
+			INDEX by_source (
+				source_app_key,
 				source_handler_key,
-				source_instance_id
+				source_instance_id,
+				offset
 			)
 		) ENGINE=InnoDB ROW_FORMAT=COMPRESSED KEY_BLOCK_SIZE=4`,
 	)

--- a/persistence/provider/sql/postgres/error.go
+++ b/persistence/provider/sql/postgres/error.go
@@ -161,14 +161,32 @@ func (d errorConverter) SelectNextEventOffset(
 	return next, convertContextErrors(ctx, err)
 }
 
-func (d errorConverter) SelectEvents(
+func (d errorConverter) SelectEventsByType(
 	ctx context.Context,
 	db *sql.DB,
 	ak string,
 	q eventstore.Query,
 	f int64,
 ) (*sql.Rows, error) {
-	rows, err := d.d.SelectEvents(ctx, db, ak, q, f)
+	rows, err := d.d.SelectEventsByType(ctx, db, ak, q, f)
+	return rows, convertContextErrors(ctx, err)
+}
+
+func (d errorConverter) SelectEventsBySource(
+	ctx context.Context,
+	db *sql.DB,
+	ak, hk, id string,
+) (*sql.Rows, error) {
+	rows, err := d.d.SelectEventsBySource(ctx, db, ak, hk, id)
+	return rows, convertContextErrors(ctx, err)
+}
+
+func (d errorConverter) SelectEventsBySourceAfterMessage(
+	ctx context.Context,
+	db *sql.DB,
+	ak, hk, id, dm string,
+) (*sql.Rows, error) {
+	rows, err := d.d.SelectEventsBySourceAfterMessage(ctx, db, ak, hk, id, dm)
 	return rows, convertContextErrors(ctx, err)
 }
 

--- a/persistence/provider/sql/postgres/error.go
+++ b/persistence/provider/sql/postgres/error.go
@@ -176,18 +176,19 @@ func (d errorConverter) SelectEventsBySource(
 	ctx context.Context,
 	db *sql.DB,
 	ak, hk, id string,
+	o uint64,
 ) (*sql.Rows, error) {
-	rows, err := d.d.SelectEventsBySource(ctx, db, ak, hk, id)
+	rows, err := d.d.SelectEventsBySource(ctx, db, ak, hk, id, o)
 	return rows, convertContextErrors(ctx, err)
 }
 
-func (d errorConverter) SelectEventsBySourceAfterMessage(
+func (d errorConverter) SelectOffsetByMessageID(
 	ctx context.Context,
 	db *sql.DB,
-	ak, hk, id, dm string,
-) (*sql.Rows, error) {
-	rows, err := d.d.SelectEventsBySourceAfterMessage(ctx, db, ak, hk, id, dm)
-	return rows, convertContextErrors(ctx, err)
+	id string,
+) (uint64, error) {
+	o, err := d.d.SelectOffsetByMessageID(ctx, db, id)
+	return o, convertContextErrors(ctx, err)
 }
 
 func (d errorConverter) ScanEvent(

--- a/persistence/provider/sql/postgres/error.go
+++ b/persistence/provider/sql/postgres/error.go
@@ -186,9 +186,9 @@ func (d errorConverter) SelectOffsetByMessageID(
 	ctx context.Context,
 	db *sql.DB,
 	id string,
-) (uint64, error) {
-	o, err := d.d.SelectOffsetByMessageID(ctx, db, id)
-	return o, convertContextErrors(ctx, err)
+) (uint64, bool, error) {
+	o, ok, err := d.d.SelectOffsetByMessageID(ctx, db, id)
+	return o, ok, convertContextErrors(ctx, err)
 }
 
 func (d errorConverter) ScanEvent(

--- a/persistence/provider/sql/postgres/eventstore.go
+++ b/persistence/provider/sql/postgres/eventstore.go
@@ -303,7 +303,12 @@ func (driver) SelectOffsetByMessageID(
 		id,
 	)
 
-	err = row.Scan(&o)
+	if err = row.Scan(&o); err == sql.ErrNoRows {
+		err = eventstore.UnknownMessageError{
+			MessageID: id,
+		}
+	}
+
 	return
 }
 

--- a/persistence/provider/sql/postgres/eventstore.go
+++ b/persistence/provider/sql/postgres/eventstore.go
@@ -180,11 +180,12 @@ func (driver) SelectNextEventOffset(
 	return next, err
 }
 
-// SelectEvents selects events from the eventstore that match the given query.
+// SelectEventsByType selects events from the eventstore that match the
+// given event types query.
 //
-// f is a filter ID, as returned by InsertEventFilter(). If the query does not
-// use a filter, f is zero.
-func (driver) SelectEvents(
+// f is a filter ID, as returned by InsertEventFilter(). If the query does
+// not use a filter, f is zero.
+func (driver) SelectEventsByType(
 	ctx context.Context,
 	db *sql.DB,
 	ak string,
@@ -245,6 +246,83 @@ func (driver) SelectEvents(
 		ctx,
 		qb.String(),
 		qb.Parameters...,
+	)
+}
+
+// SelectEventsBySource selects events from the eventstore that match the
+// given source, namely the source's key and id.
+func (driver) SelectEventsBySource(
+	ctx context.Context,
+	db *sql.DB,
+	ak, hk, id string,
+) (*sql.Rows, error) {
+	return db.QueryContext(
+		ctx,
+		`SELECT
+			e.offset,
+			e.message_id,
+			e.causation_id,
+			e.correlation_id,
+			e.source_app_name,
+			e.source_app_key,
+			e.source_handler_name,
+			e.source_handler_key,
+			e.source_instance_id,
+			e.created_at,
+			e.description,
+			e.portable_name,
+			e.media_type,
+			e.data
+		FROM infix.event AS e
+		WHERE e.source_app_key = $1
+		AND e.source_handler_key = $2
+		AND e.source_instance_id = $3
+		ORDER BY e.offset`,
+		ak,
+		hk,
+		id,
+	)
+}
+
+// SelectEventsBySourceAfterMessage selects events from the eventstore that
+// match the given source, namely the source's key and id. The events must
+// after the specified message d.
+func (driver) SelectEventsBySourceAfterMessage(
+	ctx context.Context,
+	db *sql.DB,
+	ak, hk, id, d string,
+) (*sql.Rows, error) {
+	return db.QueryContext(
+		ctx,
+		`SELECT
+			e.offset,
+			e.message_id,
+			e.causation_id,
+			e.correlation_id,
+			e.source_app_name,
+			e.source_app_key,
+			e.source_handler_name,
+			e.source_handler_key,
+			e.source_instance_id,
+			e.created_at,
+			e.description,
+			e.portable_name,
+			e.media_type,
+			e.data
+		FROM infix.event AS e
+		WHERE e.source_app_key = $1
+		AND e.source_handler_key = $2
+		AND e.source_instance_id = $3
+		AND e.offset > (
+			SELECT e1.offset
+			FROM infix.event AS e1
+			WHERE e1.message_id = $4
+		)
+		ORDER BY e.offset`,
+		ak,
+		hk,
+		id,
+		d,
 	)
 }
 

--- a/persistence/provider/sql/postgres/eventstore.go
+++ b/persistence/provider/sql/postgres/eventstore.go
@@ -288,12 +288,13 @@ func (driver) SelectEventsBySource(
 }
 
 // SelectOffsetByMessageID selects the offset of the message with the given
-// ID.
+// ID. It returns false as a second return value if the message cannot be
+// found.
 func (driver) SelectOffsetByMessageID(
 	ctx context.Context,
 	db *sql.DB,
 	id string,
-) (o uint64, err error) {
+) (uint64, bool, error) {
 	row := db.QueryRowContext(
 		ctx,
 		`SELECT
@@ -303,13 +304,13 @@ func (driver) SelectOffsetByMessageID(
 		id,
 	)
 
-	if err = row.Scan(&o); err == sql.ErrNoRows {
-		err = eventstore.UnknownMessageError{
-			MessageID: id,
-		}
+	var o uint64
+	err := row.Scan(&o)
+	if err == sql.ErrNoRows {
+		return 0, false, nil
 	}
 
-	return
+	return o, true, err
 }
 
 // ScanEvent scans the next event from a row-set returned by SelectEvents().

--- a/persistence/provider/sql/postgres/schema.go
+++ b/persistence/provider/sql/postgres/schema.go
@@ -77,7 +77,7 @@ func createEventStoreSchema(ctx context.Context, db *sql.DB) {
 		db,
 		`CREATE TABLE infix.event (
 			"offset"            BIGINT NOT NULL,
-			message_id          TEXT NOT NULL,
+			message_id          TEXT NOT NULL UNIQUE,
 			causation_id        TEXT NOT NULL,
 			correlation_id      TEXT NOT NULL,
 			source_app_name     TEXT NOT NULL,
@@ -98,12 +98,21 @@ func createEventStoreSchema(ctx context.Context, db *sql.DB) {
 	sqlx.Exec(
 		ctx,
 		db,
-		`CREATE INDEX repository_query ON infix.event (
+		`CREATE INDEX by_type ON infix.event (
 			source_app_key,
 			portable_name,
-			message_id,
+			"offset"
+		)`,
+	)
+
+	sqlx.Exec(
+		ctx,
+		db,
+		`CREATE INDEX by_source ON infix.event (
+			source_app_key,
 			source_handler_key,
-			source_instance_id
+			source_instance_id,
+			"offset"
 		)`,
 	)
 

--- a/persistence/provider/sql/postgres/schema.go
+++ b/persistence/provider/sql/postgres/schema.go
@@ -101,7 +101,7 @@ func createEventStoreSchema(ctx context.Context, db *sql.DB) {
 		`CREATE INDEX repository_query ON infix.event (
 			source_app_key,
 			portable_name,
-			"offset",
+			messsage_id,
 			source_handler_key,
 			source_instance_id
 		)`,

--- a/persistence/provider/sql/postgres/schema.go
+++ b/persistence/provider/sql/postgres/schema.go
@@ -101,7 +101,7 @@ func createEventStoreSchema(ctx context.Context, db *sql.DB) {
 		`CREATE INDEX repository_query ON infix.event (
 			source_app_key,
 			portable_name,
-			messsage_id,
+			message_id,
 			source_handler_key,
 			source_instance_id
 		)`,

--- a/persistence/provider/sql/sqlite/eventstore.go
+++ b/persistence/provider/sql/sqlite/eventstore.go
@@ -344,7 +344,12 @@ func (driver) SelectOffsetByMessageID(
 		id,
 	)
 
-	err = row.Scan(&o)
+	if err = row.Scan(&o); err == sql.ErrNoRows {
+		err = eventstore.UnknownMessageError{
+			MessageID: id,
+		}
+	}
+
 	return
 }
 

--- a/persistence/provider/sql/sqlite/eventstore.go
+++ b/persistence/provider/sql/sqlite/eventstore.go
@@ -296,6 +296,7 @@ func (driver) SelectEventsBySource(
 	ctx context.Context,
 	db *sql.DB,
 	ak, hk, id string,
+	o uint64,
 ) (*sql.Rows, error) {
 	return db.QueryContext(
 		ctx,
@@ -318,53 +319,33 @@ func (driver) SelectEventsBySource(
 		WHERE e.source_app_key = $1
 		AND e.source_handler_key = $2
 		AND e.source_instance_id = $3
+		AND e.offset >= $4
 		ORDER BY e.offset`,
 		ak,
 		hk,
 		id,
+		o,
 	)
 }
 
-// SelectEventsBySourceAfterMessage selects events from the eventstore that
-// match the given source, namely the source's key and id. The events must
-// after the specified message d.
-func (driver) SelectEventsBySourceAfterMessage(
+// SelectOffsetByMessageID selects the offset of the message with the given
+// ID.
+func (driver) SelectOffsetByMessageID(
 	ctx context.Context,
 	db *sql.DB,
-	ak, hk, id, d string,
-) (*sql.Rows, error) {
-	return db.QueryContext(
+	id string,
+) (o uint64, err error) {
+	row := db.QueryRowContext(
 		ctx,
 		`SELECT
-			e.offset,
-			e.message_id,
-			e.causation_id,
-			e.correlation_id,
-			e.source_app_name,
-			e.source_app_key,
-			e.source_handler_name,
-			e.source_handler_key,
-			e.source_instance_id,
-			e.created_at,
-			e.description,
-			e.portable_name,
-			e.media_type,
-			e.data
+			e.offset
 		FROM event AS e
-		WHERE e.source_app_key = $1
-		AND e.source_handler_key = $2
-		AND e.source_instance_id = $3
-		AND e.offset > (
-			SELECT e1.offset
-			FROM event AS e1
-			WHERE e1.message_id = $4
-		)
-		ORDER BY e.offset`,
-		ak,
-		hk,
+		WHERE e.message_id = $1`,
 		id,
-		d,
 	)
+
+	err = row.Scan(&o)
+	return
 }
 
 // ScanEvent scans the next event from a row-set returned by SelectEvents().

--- a/persistence/provider/sql/sqlite/eventstore.go
+++ b/persistence/provider/sql/sqlite/eventstore.go
@@ -221,11 +221,12 @@ func (driver) SelectNextEventOffset(
 	return next, err
 }
 
-// SelectEvents selects events from the eventstore that match the given query.
+// SelectEventsByType selects events from the eventstore that match the
+// given event types query.
 //
-// f is a filter ID, as returned by InsertEventFilter(). If the query does not
-// use a filter, f is zero.
-func (driver) SelectEvents(
+// f is a filter ID, as returned by InsertEventFilter(). If the query does
+// not use a filter, f is zero.
+func (driver) SelectEventsByType(
 	ctx context.Context,
 	db *sql.DB,
 	ak string,
@@ -286,6 +287,83 @@ func (driver) SelectEvents(
 		ctx,
 		qb.String(),
 		qb.Parameters...,
+	)
+}
+
+// SelectEventsBySource selects events from the eventstore that match the
+// given source, namely the source's key and id.
+func (driver) SelectEventsBySource(
+	ctx context.Context,
+	db *sql.DB,
+	ak, hk, id string,
+) (*sql.Rows, error) {
+	return db.QueryContext(
+		ctx,
+		`SELECT
+			e.offset,
+			e.message_id,
+			e.causation_id,
+			e.correlation_id,
+			e.source_app_name,
+			e.source_app_key,
+			e.source_handler_name,
+			e.source_handler_key,
+			e.source_instance_id,
+			e.created_at,
+			e.description,
+			e.portable_name,
+			e.media_type,
+			e.data
+		FROM event AS e
+		WHERE e.source_app_key = $1
+		AND e.source_handler_key = $2
+		AND e.source_instance_id = $3
+		ORDER BY e.offset`,
+		ak,
+		hk,
+		id,
+	)
+}
+
+// SelectEventsBySourceAfterMessage selects events from the eventstore that
+// match the given source, namely the source's key and id. The events must
+// after the specified message d.
+func (driver) SelectEventsBySourceAfterMessage(
+	ctx context.Context,
+	db *sql.DB,
+	ak, hk, id, d string,
+) (*sql.Rows, error) {
+	return db.QueryContext(
+		ctx,
+		`SELECT
+			e.offset,
+			e.message_id,
+			e.causation_id,
+			e.correlation_id,
+			e.source_app_name,
+			e.source_app_key,
+			e.source_handler_name,
+			e.source_handler_key,
+			e.source_instance_id,
+			e.created_at,
+			e.description,
+			e.portable_name,
+			e.media_type,
+			e.data
+		FROM event AS e
+		WHERE e.source_app_key = $1
+		AND e.source_handler_key = $2
+		AND e.source_instance_id = $3
+		AND e.offset > (
+			SELECT e1.offset
+			FROM event AS e1
+			WHERE e1.message_id = $4
+		)
+		ORDER BY e.offset`,
+		ak,
+		hk,
+		id,
+		d,
 	)
 }
 

--- a/persistence/provider/sql/sqlite/schema.go
+++ b/persistence/provider/sql/sqlite/schema.go
@@ -113,7 +113,7 @@ func createEventStoreSchema(ctx context.Context, db *sql.DB) {
 		`CREATE INDEX repository_query ON event (
 			source_app_key,
 			portable_name,
-			offset,
+			message_id,
 			source_handler_key,
 			source_instance_id
 		)`,

--- a/persistence/provider/sql/sqlite/schema.go
+++ b/persistence/provider/sql/sqlite/schema.go
@@ -113,7 +113,7 @@ func createEventStoreSchema(ctx context.Context, db *sql.DB) {
 		`CREATE INDEX by_type ON event (
 			source_app_key,
 			portable_name,
-			"offset"
+			offset
 		)`,
 	)
 
@@ -124,7 +124,7 @@ func createEventStoreSchema(ctx context.Context, db *sql.DB) {
 			source_app_key,
 			source_handler_key,
 			source_instance_id,
-			"offset"
+			offset
 		)`,
 	)
 

--- a/persistence/provider/sql/sqlite/schema.go
+++ b/persistence/provider/sql/sqlite/schema.go
@@ -89,7 +89,7 @@ func createEventStoreSchema(ctx context.Context, db *sql.DB) {
 		db,
 		`CREATE TABLE event (
 			offset              INTEGER NOT NULL,
-			message_id          TEXT NOT NULL,
+			message_id          TEXT NOT NULL UNIQUE,
 			causation_id        TEXT NOT NULL,
 			correlation_id      TEXT NOT NULL,
 			source_app_name     TEXT NOT NULL,
@@ -110,12 +110,21 @@ func createEventStoreSchema(ctx context.Context, db *sql.DB) {
 	sqlx.Exec(
 		ctx,
 		db,
-		`CREATE INDEX repository_query ON event (
+		`CREATE INDEX by_type ON event (
 			source_app_key,
 			portable_name,
-			message_id,
+			"offset"
+		)`,
+	)
+
+	sqlx.Exec(
+		ctx,
+		db,
+		`CREATE INDEX by_source ON event (
+			source_app_key,
 			source_handler_key,
-			source_instance_id
+			source_instance_id,
+			"offset"
 		)`,
 	)
 

--- a/persistence/subsystem/eventstore/repository.go
+++ b/persistence/subsystem/eventstore/repository.go
@@ -13,7 +13,7 @@ type Repository interface {
 	// key and id.
 	//
 	// d is the optional parameter, it represents ID of the message that was
-	// recorded when the instance was last destroyed, if any.
+	// recorded when the instance was last destroyed.
 	LoadEventsForAggregate(
 		ctx context.Context,
 		hk, id, d string,

--- a/persistence/subsystem/eventstore/repository.go
+++ b/persistence/subsystem/eventstore/repository.go
@@ -9,6 +9,17 @@ type Repository interface {
 	// NextEventOffset returns the next "unused" offset within the store.
 	NextEventOffset(ctx context.Context) (uint64, error)
 
+	// LoadEventsForAggregate loads the events for the aggregate with the given
+	// key and id.
+	//
+	// d is the optional parameter, it represents ID of the message that was
+	// recorded when the instance was last destroyed, if any.
+	LoadEventsForAggregate(
+		ctx context.Context,
+		hk, id string,
+		d string,
+	) (Result, error)
+
 	// QueryEvents queries events in the repository.
 	QueryEvents(ctx context.Context, q Query) (Result, error)
 }

--- a/persistence/subsystem/eventstore/repository.go
+++ b/persistence/subsystem/eventstore/repository.go
@@ -9,12 +9,12 @@ type Repository interface {
 	// NextEventOffset returns the next "unused" offset within the store.
 	NextEventOffset(ctx context.Context) (uint64, error)
 
-	// LoadEventsForAggregate loads the events for the aggregate with the given
-	// key and id.
+	// LoadEventsBySource loads the events produced by the specified source with
+	// the given handler key and id.
 	//
 	// d is the optional parameter, it represents ID of the message that was
 	// recorded when the instance was last destroyed.
-	LoadEventsForAggregate(
+	LoadEventsBySource(
 		ctx context.Context,
 		hk, id, d string,
 	) (Result, error)

--- a/persistence/subsystem/eventstore/repository.go
+++ b/persistence/subsystem/eventstore/repository.go
@@ -16,8 +16,7 @@ type Repository interface {
 	// recorded when the instance was last destroyed, if any.
 	LoadEventsForAggregate(
 		ctx context.Context,
-		hk, id string,
-		d string,
+		hk, id, d string,
 	) (Result, error)
 
 	// QueryEvents queries events in the repository.

--- a/persistence/subsystem/eventstore/repository.go
+++ b/persistence/subsystem/eventstore/repository.go
@@ -9,11 +9,15 @@ type Repository interface {
 	// NextEventOffset returns the next "unused" offset within the store.
 	NextEventOffset(ctx context.Context) (uint64, error)
 
-	// LoadEventsBySource loads the events produced by the specified source with
-	// the given handler key and id.
+	// LoadEventsBySource loads the events produced by a specific handler.
 	//
-	// d is the optional parameter, it represents ID of the message that was
-	// recorded when the instance was last destroyed.
+	// hk is the handler's identity key.
+	//
+	// id is the instance ID, which must be empty if the handler type does not
+	// use instances.
+	//
+	// m is ID of a "barrier" message. If supplied, the results are limited to
+	// events with higher offsets than the barrier message.
 	LoadEventsBySource(
 		ctx context.Context,
 		hk, id, d string,

--- a/persistence/subsystem/eventstore/repository.go
+++ b/persistence/subsystem/eventstore/repository.go
@@ -6,7 +6,7 @@ import (
 )
 
 // UnknownMessageError is the error returned  by Repository.LoadEventsBySource()
-// method when no message is found.
+// method if the barrier message can not be found.
 type UnknownMessageError struct {
 	MessageID string
 }
@@ -36,7 +36,7 @@ type Repository interface {
 	// cannot be found, UnknownMessageError is returned.
 	LoadEventsBySource(
 		ctx context.Context,
-		hk, id, d string,
+		hk, id, m string,
 	) (Result, error)
 
 	// QueryEvents queries events in the repository.

--- a/persistence/subsystem/eventstore/repository.go
+++ b/persistence/subsystem/eventstore/repository.go
@@ -2,7 +2,22 @@ package eventstore
 
 import (
 	"context"
+	"fmt"
 )
+
+// UnknownMessageError is the error returned  by Repository.LoadEventsBySource()
+// method when no message is found.
+type UnknownMessageError struct {
+	MessageID string
+}
+
+// Error returns a string representation of UnknownMessageError.
+func (e UnknownMessageError) Error() string {
+	return fmt.Sprintf(
+		"message with ID '%s' cannot be found",
+		e.MessageID,
+	)
+}
 
 // Repository is an interface for reading persisted event messages.
 type Repository interface {
@@ -17,7 +32,8 @@ type Repository interface {
 	// use instances.
 	//
 	// m is ID of a "barrier" message. If supplied, the results are limited to
-	// events with higher offsets than the barrier message.
+	// events with higher offsets than the barrier message. If the message
+	// cannot be found, UnknownMessageError is returned.
 	LoadEventsBySource(
 		ctx context.Context,
 		hk, id, d string,

--- a/persistence/subsystem/eventstore/repository_test.go
+++ b/persistence/subsystem/eventstore/repository_test.go
@@ -1,7 +1,9 @@
 package eventstore_test
 
 import (
+	dogmafixtures "github.com/dogmatiq/dogma/fixtures"
 	"github.com/dogmatiq/infix/draftspecs/envelopespec"
+	infixfixtures "github.com/dogmatiq/infix/fixtures"
 	"github.com/dogmatiq/infix/persistence/subsystem/eventstore"
 	. "github.com/dogmatiq/infix/persistence/subsystem/eventstore"
 	. "github.com/onsi/ginkgo"
@@ -171,5 +173,20 @@ var _ = Describe("type Query", func() {
 				},
 			),
 		)
+	})
+})
+
+var _ = Describe("type UnknownMessageError", func() {
+	Describe("func Error()", func() {
+		It("includes the message ID of the unknown message", func() {
+			env := infixfixtures.NewEnvelope("<message-0>", dogmafixtures.MessageA1)
+			err := UnknownMessageError{
+				MessageID: env.MetaData.MessageId,
+			}
+
+			Expect(err).To(
+				MatchError("message with ID '" + env.MetaData.MessageId + "' cannot be found"),
+			)
+		})
 	})
 })


### PR DESCRIPTION
This PR partially addresses #220 by adding `LoadEventsBySource()` method to `eventstore.Repository` and modifying the implementations of `eventstore.Transaction.SaveEvent()` method to persist message ID in a separate field (if not doing that already) so that `eventstore.Repository.LoadEventsForAggregate()` method can load source events from the given message ID.