### PR TITLE
Do not require context to call `Queue.Track()`.

### DIFF
--- a/pipeline/queue.go
+++ b/pipeline/queue.go
@@ -65,14 +65,16 @@ func (s *QueueSource) Run(ctx context.Context) error {
 // is enqueued.
 func TrackWithQueue(q *queue.Queue) QueueObserver {
 	return func(
-		ctx context.Context,
+		_ context.Context,
 		parcels []*parcel.Parcel,
 		items []*queuestore.Item,
 	) error {
 		for i, p := range parcels {
-			if err := q.Track(ctx, p, items[i]); err != nil {
-				return err
+			m := queue.Message{
+				Parcel: p,
+				Item:   items[i],
 			}
+			q.Track(m)
 		}
 
 		return nil

--- a/queue/executor.go
+++ b/queue/executor.go
@@ -37,5 +37,7 @@ func (x *CommandExecutor) ExecuteCommand(ctx context.Context, m dogma.Message) e
 
 	i.Revision++
 
-	return x.Queue.Track(ctx, p, i)
+	x.Queue.Track(Message{p, i})
+
+	return nil
 }

--- a/queue/message.go
+++ b/queue/message.go
@@ -1,0 +1,12 @@
+package queue
+
+import (
+	"github.com/dogmatiq/infix/parcel"
+	"github.com/dogmatiq/infix/persistence/subsystem/queuestore"
+)
+
+// Message is a message on the queue.
+type Message struct {
+	Parcel *parcel.Parcel
+	Item   *queuestore.Item
+}

--- a/queue/request_test.go
+++ b/queue/request_test.go
@@ -378,15 +378,15 @@ var _ = Describe("type Request", func() {
 
 		It("does not block, even if the internal buffer is full", func() {
 			// Fill the buffer.
-			err := queue.Track(
-				ctx,
-				parcel1,
-				&queuestore.Item{
-					Revision: 1,
-					Envelope: parcel1.Envelope,
+			queue.Track(
+				Message{
+					Parcel: parcel1,
+					Item: &queuestore.Item{
+						Revision: 1,
+						Envelope: parcel1.Envelope,
+					},
 				},
 			)
-			Expect(err).ShouldNot(HaveOccurred())
 
 			done := make(chan struct{})
 			go func() {


### PR DESCRIPTION
This PR changes `Queue.Track()` so that it cannot timeout or return an error.

Either the message is added to the tracking queue, or the "non-exhaustive" flag is set so that the queue knows it doesn't have everything in memory.