### PR TITLE
Replace `persistence.Result.EventStoreItems` with `EventOffsets`.

### DIFF
--- a/handler/entrypoint_test.go
+++ b/handler/entrypoint_test.go
@@ -12,7 +12,6 @@ import (
 	. "github.com/dogmatiq/infix/handler"
 	"github.com/dogmatiq/infix/parcel"
 	"github.com/dogmatiq/infix/persistence"
-	"github.com/dogmatiq/infix/persistence/subsystem/eventstore"
 	"github.com/dogmatiq/infix/persistence/subsystem/queuestore"
 	"github.com/dogmatiq/infix/queue"
 	. "github.com/jmalloc/gomegax"
@@ -105,15 +104,9 @@ var _ = Describe("type EntryPoint", func() {
 					persistence.Batch,
 				) (persistence.Result, error) {
 					return persistence.Result{
-						EventStoreItems: []*eventstore.Item{
-							{
-								Offset:   0,
-								Envelope: unqueuedEvent.Envelope,
-							},
-							{
-								Offset:   1,
-								Envelope: queuedEvent.Envelope,
-							},
+						EventOffsets: map[string]uint64{
+							unqueuedEvent.Envelope.MetaData.MessageId: 0,
+							queuedEvent.Envelope.MetaData.MessageId:   1,
 						},
 					}, nil
 				}

--- a/handler/unitofwork.go
+++ b/handler/unitofwork.go
@@ -94,18 +94,9 @@ func (w *UnitOfWork) saveEvent(p *parcel.Parcel) {
 
 // populateEventOffsets updates the events in w.result with their offsets.
 func (w *UnitOfWork) populateEventOffsets(pr persistence.Result) {
-	// Note: we just iterate through the events in the result to find each match
-	// rather than maintaining a map or any other more elaborate data structure.
-	// This is because we expect the vast majority of results to contain 0 or 1
-	// event.
-	for _, item := range pr.EventStoreItems {
-		for i := range w.result.Events {
-			ev := &w.result.Events[i]
-
-			if ev.Parcel.Envelope.MetaData.MessageId == item.ID() {
-				ev.Offset = item.Offset
-			}
-		}
+	for i := range w.result.Events {
+		ev := &w.result.Events[i]
+		ev.Offset = pr.EventOffsets[ev.Parcel.Envelope.MetaData.MessageId] // TODO: https://github.com/dogmatiq/infix/issues/268
 	}
 }
 

--- a/persistence/internal/providertest/eventop.go
+++ b/persistence/internal/providertest/eventop.go
@@ -68,7 +68,7 @@ func declareEventOperationTests(tc *common.TestContext) {
 				))
 			})
 
-			ginkgo.It("has a corresponding item in the batch result", func() {
+			ginkgo.It("has a corresponding item in the result", func() {
 				res := persist(
 					tc.Context,
 					dataStore,
@@ -80,21 +80,11 @@ func declareEventOperationTests(tc *common.TestContext) {
 					},
 				)
 
-				gomega.Expect(res.EventStoreItems).To(
-					gomega.ConsistOf(
-						gomegax.EqualX(
-							&eventstore.Item{
-								Offset:   0,
-								Envelope: env0,
-							},
-						),
-						gomegax.EqualX(
-							&eventstore.Item{
-								Offset:   1,
-								Envelope: env1,
-							},
-						),
-					),
+				gomega.Expect(res.EventOffsets).To(
+					gomega.Equal(map[string]uint64{
+						env0.MetaData.MessageId: 0,
+						env1.MetaData.MessageId: 1,
+					}),
 				)
 			})
 
@@ -118,9 +108,13 @@ func declareEventOperationTests(tc *common.TestContext) {
 					)
 
 					m.Lock()
-					for _, i := range res.EventStoreItems {
-						expect = append(expect, *i)
-					}
+					expect = append(
+						expect,
+						eventstore.Item{
+							Offset:   res.EventOffsets[env.MetaData.MessageId],
+							Envelope: env,
+						},
+					)
 					m.Unlock()
 				}
 

--- a/persistence/persister.go
+++ b/persistence/persister.go
@@ -3,8 +3,6 @@ package persistence
 import (
 	"context"
 	"fmt"
-
-	"github.com/dogmatiq/infix/persistence/subsystem/eventstore"
 )
 
 // A Persister is an interface for committing batches of atomic operations to
@@ -19,8 +17,9 @@ type Persister interface {
 
 // Result is the result of a successfully persisted batch of operations.
 type Result struct {
-	// EventStoreItems contains the events from SaveEvent operations.
-	EventStoreItems []*eventstore.Item
+	// EventOffset contains the offsets of the events saved within the batch,
+	// keyed by their message ID.
+	EventOffsets map[string]uint64
 }
 
 // ConflictError is an error indicating one or more operations within a batch

--- a/persistence/provider/boltdb/eventstore.go
+++ b/persistence/provider/boltdb/eventstore.go
@@ -83,13 +83,11 @@ func (t *transaction) SaveEvent(
 		marshalUint64(o+1),
 	)
 
-	t.result.EventStoreItems = append(
-		t.result.EventStoreItems,
-		&eventstore.Item{
-			Offset:   o,
-			Envelope: env,
-		},
-	)
+	if t.result.EventOffsets == nil {
+		t.result.EventOffsets = map[string]uint64{}
+	}
+
+	t.result.EventOffsets[env.MetaData.MessageId] = o
 
 	return o, nil
 }

--- a/persistence/provider/memory/transaction.go
+++ b/persistence/provider/memory/transaction.go
@@ -42,7 +42,7 @@ func (t *transaction) Commit(
 	t.ds.db.queue.apply(&t.queue)
 
 	return persistence.TransactionResult{
-		EventStoreItems: t.event.items,
+		EventOffsets: t.event.offsets,
 	}, nil
 }
 

--- a/persistence/provider/sql/eventstore.go
+++ b/persistence/provider/sql/eventstore.go
@@ -134,13 +134,11 @@ func (t *transaction) SaveEvent(
 		return 0, err
 	}
 
-	t.result.EventStoreItems = append(
-		t.result.EventStoreItems,
-		&eventstore.Item{
-			Offset:   next,
-			Envelope: env,
-		},
-	)
+	if t.result.EventOffsets == nil {
+		t.result.EventOffsets = map[string]uint64{}
+	}
+
+	t.result.EventOffsets[env.MetaData.MessageId] = next
 
 	return next, nil
 }

--- a/persistence/transaction_test.go
+++ b/persistence/transaction_test.go
@@ -9,9 +9,7 @@ import (
 	. "github.com/dogmatiq/infix/fixtures"
 	. "github.com/dogmatiq/infix/persistence"
 	"github.com/dogmatiq/infix/persistence/provider/memory"
-	"github.com/dogmatiq/infix/persistence/subsystem/eventstore"
 	"github.com/dogmatiq/infix/persistence/subsystem/queuestore"
-	. "github.com/jmalloc/gomegax"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -97,21 +95,11 @@ var _ = Describe("func WithTransaction", func() {
 		)
 
 		Expect(err).ShouldNot(HaveOccurred())
-		Expect(result.EventStoreItems).NotTo(BeEmpty())
-		Expect(result.EventStoreItems).To(
-			EqualX([]*eventstore.Item{
-				{
-					Offset:   0,
-					Envelope: env1,
-				},
-				{
-					Offset:   1,
-					Envelope: env2,
-				},
-				{
-					Offset:   2,
-					Envelope: env3,
-				},
+		Expect(result.EventOffsets).To(
+			Equal(map[string]uint64{
+				env1.MetaData.MessageId: 0,
+				env2.MetaData.MessageId: 1,
+				env3.MetaData.MessageId: 2,
 			}),
 		)
 	})


### PR DESCRIPTION
As it turns out there's nowhere that we actually need the eventstore items directly, so in the interest of simplicity and the whole "keeping the persistence layer dumb" idea, I've replaced the items in the result with a map of message ID to offset.