### PR TITLE
Simplify `queue.Queue` internals and naming.

### DIFF
--- a/handler/queue.go
+++ b/handler/queue.go
@@ -52,7 +52,7 @@ func (c *QueueConsumer) Run(ctx context.Context) error {
 			}
 
 			if err := c.Semaphore.Acquire(ctx, 1); err != nil {
-				c.Queue.Requeue(m)
+				c.Queue.Nack(m)
 				return err
 			}
 
@@ -117,7 +117,7 @@ func (a *queueAcknowledger) Ack(ctx context.Context, b persistence.Batch) (persi
 		return persistence.Result{}, err
 	}
 
-	a.queue.Remove(a.message)
+	a.queue.Ack(a.message)
 	return res, nil
 }
 
@@ -150,7 +150,7 @@ func (a *queueAcknowledger) Nack(ctx context.Context, cause error) error {
 	}
 
 	a.message.Revision++
-	a.queue.Requeue(a.message)
+	a.queue.Nack(a.message)
 
 	return nil
 }

--- a/queue/queue.go
+++ b/queue/queue.go
@@ -45,12 +45,10 @@ type Queue struct {
 	pending    kyu.PDeque          // priority queue of messages that haven't been popped
 	exhaustive bool                // true if all queued messages are in memory
 
-	once    sync.Once
-	done    chan struct{}  // closed when Run() exits
-	add     chan []Message // messages to start tracking
-	requeue chan Message   // popped messages that need to return to the queue
-	remove  chan Message   // popped messages that were removed from the queue
-	pop     chan Message   // delivers messages to consumers
+	once      sync.Once
+	done      chan struct{}    // closed when Run() exits
+	pop       chan Message     // delivers messages to consumers
+	mutations chan func() bool // sends "mutation" function to Run()
 }
 
 // Pop returns the message at the front of the queue.
@@ -74,29 +72,37 @@ func (q *Queue) Pop(ctx context.Context) (Message, error) {
 // Add begins tracking messages that have already been persisted.
 func (q *Queue) Add(messages []Message) {
 	q.init()
-
-	select {
-	case q.add <- messages:
-		return // keep to see coverage
-	case <-q.done:
-		return // keep to see coverage
-	}
+	q.mutate(func() bool {
+		return q.track(messages)
+	})
 }
 
 // Requeue returns a popped message to the queue.
 func (q *Queue) Requeue(m Message) {
-	select {
-	case q.requeue <- m:
-		return // keep to see coverage
-	case <-q.done:
-		return // keep to see coverage
-	}
+	q.mutate(func() bool {
+		e := q.pending.Push(m)
+		return q.pending.IsFront(e)
+	})
 }
 
 // Remove stops tracking a popped message.
 func (q *Queue) Remove(m Message) {
+	q.mutate(func() bool {
+		delete(q.tracked, m.ID())
+		return !q.exhaustive && len(q.tracked) == 0
+	})
+}
+
+// mutate performs some modification to the queue in the context of Run().
+//
+// If fn() returns true, Run() starts a new call to tick(), re-evaluating the
+// message at the head of the queue.
+//
+// It returns once the mutation has been received by Run()'s goroutine, but does
+// NOT block until fn() has returned.
+func (q *Queue) mutate(fn func() bool) {
 	select {
-	case q.remove <- m:
+	case q.mutations <- fn:
 		return // keep to see coverage
 	case <-q.done:
 		return // keep to see coverage
@@ -181,31 +187,10 @@ func (q *Queue) tick(ctx context.Context) error {
 			q.pending.Pop()
 			return nil
 
-		case messages := <-q.add:
-			// New messages have been added to the queue.
-			if q.track(messages) {
-				// And one of them has become the new head, return to allow a
-				// new call to peek().
-				return nil
-			}
-
-		case m := <-q.requeue:
-			// A popped message has been returned to the queue.
-			e := q.pending.Push(m)
-
-			if q.pending.IsFront(e) {
-				// And it's become the head of the queue, return to allow a new
-				// call to peek().
-				return nil
-			}
-
-		case m := <-q.remove:
-			// A popped message has been removed from the queue.
-			delete(q.tracked, m.ID())
-
-			if !q.exhaustive && len(q.tracked) == 0 {
-				// We have nothing left in memory, and we suspect there is more
-				// to load, return to allow a new call to peek().
+		case fn := <-q.mutations:
+			if fn() {
+				// The action signalled that the head of the queue should be
+				// re-evaluated, so we return to start a new loop.
 				return nil
 			}
 		}
@@ -324,9 +309,7 @@ func (q *Queue) init() {
 		}
 
 		q.done = make(chan struct{})
-		q.add = make(chan []Message)
-		q.requeue = make(chan Message)
-		q.remove = make(chan Message)
 		q.pop = make(chan Message)
+		q.mutations = make(chan func() bool)
 	})
 }


### PR DESCRIPTION
This PR simplifies the internals of `queue.Queue` making it easier to add additional operations that manipulate the messages on the queue.

