### PR TITLE
Replace `UnitOfWork.Observe()` with `Defer()`.

### DIFF
--- a/app.go
+++ b/app.go
@@ -199,13 +199,9 @@ func (e *Engine) newEntryPoint(
 	return &handler.EntryPoint{
 		QueueEvents: nil,
 		Handler:     hf.handler,
-		Observers: []handler.Observer{
-			func(r handler.Result, err error) {
-				if err == nil {
-					c.Add(r.Events)
-					q.Add(r.Queued)
-				}
-			},
+		OnSuccess: func(r handler.Result) {
+			c.Add(r.Events)
+			q.Add(r.Queued)
 		},
 	}
 }

--- a/handler/cache/cache.go
+++ b/handler/cache/cache.go
@@ -55,9 +55,9 @@ func (c *Cache) Acquire(
 		return nil, err
 	}
 
-	// Add an observer that releases the lock on the cache record only after the
-	// unit-of-work is complete.
-	w.Observe(func(_ handler.Result, err error) {
+	// Defer a function that releases the lock on the cache record only after
+	// the unit-of-work is complete.
+	w.Defer(func(_ handler.Result, err error) {
 		if err != nil {
 			// The unit-of-work was failed, so we forcibly discard the record.
 			// The assumption is that the contents of the record was modified in

--- a/handler/queue_test.go
+++ b/handler/queue_test.go
@@ -49,7 +49,8 @@ var _ = Describe("type QueueConsumer", func() {
 		consumer = &QueueConsumer{
 			Queue: mqueue,
 			EntryPoint: &EntryPoint{
-				Handler: handler,
+				Handler:   handler,
+				OnSuccess: func(Result) {},
 			},
 			Persister:       dataStore,
 			BackoffStrategy: backoff.Constant(1 * time.Millisecond), // use a small but non-zero backoff to make the tests predictable


### PR DESCRIPTION
This PR replaces the concept of "unit of work observers" with "deferred functions", similar to Go's `defer` keyword. The upshot of this is that the unit-of-work now provides guarantees about the order in which the functions will be called.

This was added to allow precise control over what code is executed while aggregate and process cache records are still held..