### PR TITLE
Disallow recreation of an aggregate instance during the same message by which it is destroyed.

### DIFF
--- a/handler/aggregate/adaptor_test.go
+++ b/handler/aggregate/adaptor_test.go
@@ -439,7 +439,7 @@ var _ = Describe("type Adaptor", func() {
 			})
 
 			When("the instance is destroyed", func() {
-				It("resets the root state within the same scope", func() {
+				It("causes Create() to panic", func() {
 					upstream.HandleCommandFunc = func(
 						s dogma.AggregateCommandScope,
 						_ dogma.Message,
@@ -447,27 +447,9 @@ var _ = Describe("type Adaptor", func() {
 						s.RecordEvent(MessageE3)
 						s.Destroy()
 
-						s.Create()
-						r := s.Root().(*AggregateRoot)
-						Expect(r.Value).To(Equal(
-							&[]dogma.Message{},
-						))
-					}
-
-					err := adaptor.HandleMessage(ctx, work, cause)
-					Expect(err).ShouldNot(HaveOccurred())
-				})
-
-				It("causes create to return true again", func() {
-					upstream.HandleCommandFunc = func(
-						s dogma.AggregateCommandScope,
-						_ dogma.Message,
-					) {
-						s.RecordEvent(MessageE3)
-						s.Destroy()
-
-						ok := s.Create()
-						Expect(ok).To(BeTrue())
+						Expect(func() {
+							s.Create()
+						}).To(PanicWith("can not create an instance that was destroyed by the same message"))
 					}
 
 					err := adaptor.HandleMessage(ctx, work, cause)

--- a/handler/aggregate/scope.go
+++ b/handler/aggregate/scope.go
@@ -37,6 +37,10 @@ func (s *scope) Create() bool {
 		return false
 	}
 
+	if s.destroyed {
+		panic("can not create an instance that was destroyed by the same message")
+	}
+
 	s.instance.InstanceExists = true
 	s.created = true
 


### PR DESCRIPTION
See also https://github.com/dogmatiq/dogma/issues/116