### PR TITLE
Allow AggregateCommandScope.Destroy() and RecordEvent() to be called in any order.

### DIFF
--- a/handler/aggregate/adaptor.go
+++ b/handler/aggregate/adaptor.go
@@ -79,15 +79,16 @@ func (a *Adaptor) HandleMessage(
 	}
 
 	a.Handler.HandleCommand(sc, p.Message)
-	sc.finalize()
 
-	if sc.lastEventID == "" {
-		// No events were recorded at all, so there's no reason to update the
-		// meta-data.
+	if !sc.changed {
+		// No events were recorded at all, and the instance was not destroyed,
+		// so there's no reason to update the meta-data.
 		return nil
 	}
 
-	inst.LastEventID = sc.lastEventID
+	if sc.destroyed {
+		inst.BarrierEventID = inst.LastEventID
+	}
 
 	w.Do(persistence.SaveAggregateMetaData{
 		MetaData: inst.AggregateMetaData,


### PR DESCRIPTION
This PR updates testkit to allow the behavior documented in [ADR-17](https://github.com/dogmatiq/dogma/blob/master/docs/adr/0017-recreate-aggregate-after-destruction.md).